### PR TITLE
Added the functionality to exclude files from backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 *.bk
 .*.sw[po]
 Cargo.lock
+.idea/
+conserve.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tempfile = "^2"
 term = "^0.4"
 time = "^0"
 vergen = "0.1.1"
+globset = "0.2"
 
 [build-dependencies]
 vergen = "~0.1.0"

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -180,10 +180,10 @@ mod tests {
         }
 
         let backup_report = Report::new();
-        BackupOptions::default().backup(af.path(), srcdir.path(), &backup_report).unwrap();
+        BackupOptions::default().backup(af.path(), srcdir.path(), &backup_report, None).unwrap();
 
         srcdir.create_file("hello2");
-        BackupOptions::default().backup(af.path(), srcdir.path(), &Report::new()).unwrap();
+        BackupOptions::default().backup(af.path(), srcdir.path(), &Report::new(), None).unwrap();
 
         af
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,7 +15,7 @@ pub fn simple_backup() {
     srcdir.create_file("hello");
     // TODO: Include a symlink only on Unix.
     let report = Report::new();
-    BackupOptions::default().backup(af.path(), srcdir.path(), &report).unwrap();
+    BackupOptions::default().backup(af.path(), srcdir.path(), &report, None).unwrap();
     {
         let cs = report.borrow_counts();
         assert_eq!(1, cs.get_count("block"));


### PR DESCRIPTION
Execute the command with excluding files like this:
```
./conserve backup archiv/ folder/ "f*"
./conserve backup archiv/ folder/ foo,bar
```

With the option verbose (-v) the output will show something like this:
```
Backup folder
Skipping foo
Backup folder/barBaz
```