### PR TITLE
Add command "debug index dump"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ protection.
 
 * Move to Rust edition 2018.
 
+* New command `conserve debug index dump`.
+
 ## Conserve 0.5.1 2018-11-11
 
 * `conserve validate` checks the archive much more thoroughly.

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -155,8 +155,8 @@ fn make_clap<'a, 'b>() -> clap::App<'a, 'b> {
                         .subcommand(
                             SubCommand::with_name("dump")
                                 .about("Show the stored index for the given band")
-                                .arg(Arg::with_name("archive").required(true))
-                                .arg(Arg::with_name("band-id").required(true)),
+                                .arg(backup_arg())
+                                .arg(Arg::with_name("archive").required(true)),
                         ),
                 ),
         )
@@ -421,7 +421,8 @@ fn debug_block_referenced(subm: &ArgMatches, report: &Report) -> Result<()> {
 fn debug_index_dump(subm: &ArgMatches, report: &Report) -> Result<()> {
     use conserve::output::ShowArchive;
     let archive = Archive::open(subm.value_of("archive").unwrap(), &report)?;
-    output::IndexDump::new(subm.value_of("band-id").unwrap()).show_archive(&archive)
+    let st = stored_tree_from_options(subm, report)?;
+    output::IndexDump::new(st.band()).show_archive(&archive)
 }
 
 fn tree_size(subm: &ArgMatches, report: &Report) -> Result<()> {

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -32,6 +32,7 @@ fn main() -> conserve::Result<()> {
         "backup" => backup,
         "debug block list" => debug_block_list,
         "debug block referenced" => debug_block_referenced,
+        "debug index dump" => debug_index_dump,
         "diff" => diff,
         "init" => init,
         "ls" => ls,
@@ -146,6 +147,16 @@ fn make_clap<'a, 'b>() -> clap::App<'a, 'b> {
                             SubCommand::with_name("referenced")
                                 .about("List hashes of all blocks referenced by an index")
                                 .arg(Arg::with_name("archive").required(true)),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("index")
+                        .about("Debug index")
+                        .subcommand(
+                            SubCommand::with_name("dump")
+                                .about("Show the stored index for the given band")
+                                .arg(Arg::with_name("archive").required(true))
+                                .arg(Arg::with_name("band-id").required(true)),
                         ),
                 ),
         )
@@ -405,6 +416,12 @@ fn debug_block_referenced(subm: &ArgMatches, report: &Report) -> Result<()> {
         report.print(&h);
     }
     Ok(())
+}
+
+fn debug_index_dump(subm: &ArgMatches, report: &Report) -> Result<()> {
+    use conserve::output::ShowArchive;
+    let archive = Archive::open(subm.value_of("archive").unwrap(), &report)?;
+    output::IndexDump::new(subm.value_of("band-id").unwrap()).show_archive(&archive)
 }
 
 fn tree_size(subm: &ArgMatches, report: &Report) -> Result<()> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -90,30 +90,21 @@ impl ShowArchive for VerboseVersionList {
 }
 
 #[derive(Debug)]
-pub struct IndexDump {
-    band_id: String,
+pub struct IndexDump<'a> {
+    band: &'a Band,
 }
 
-impl IndexDump {
-    pub fn new(band_id: &str) -> Self {
-        Self {
-            band_id: band_id.to_string(),
-        }
+impl<'a> IndexDump<'a> {
+    pub fn new(band: &'a Band) -> Self {
+        Self { band }
     }
 }
 
-impl ShowArchive for IndexDump {
+impl<'a> ShowArchive for IndexDump<'a> {
     fn show_archive(&self, archive: &Archive) -> Result<()> {
         let report = archive.report();
-        let band_id = BandId::from_string(&self.band_id)?;
-        let band = match Band::open(&archive, &band_id) {
-            Ok(band) => band,
-            Err(e) => {
-                report.problem(&format!("Failed to open band {:?}: {:?}", band_id, e));
-                return Err(e);
-            }
-        };
-        let index_entries = band
+        let index_entries = self
+            .band
             .index()
             .iter(&excludes::excludes_nothing(), &report)
             .unwrap()

--- a/src/output.rs
+++ b/src/output.rs
@@ -119,9 +119,8 @@ impl ShowArchive for IndexDump {
             .unwrap()
             .filter_map(|i| i.ok())
             .collect::<Vec<Entry>>();
-        for entry in index_entries {
-            println!("{}", serde_json::to_string_pretty(&entry)?);
-        }
+        let output = serde_json::to_string_pretty(&index_entries)?;
+        report.print(&output);
         Ok(())
     }
 }


### PR DESCRIPTION
Dump the index for the given band in pretty-printed JSON.

I'm not sure how should I address something though; the progress is printed in the first line of the output due to the `ReadIndex` iterator calling `Report.increment`.

Closes #73 