### PR TITLE
Use a BlockHash type rather than strings

### DIFF
--- a/src/apath.rs
+++ b/src/apath.rs
@@ -241,6 +241,7 @@ pub struct CheckOrder {
 // GRCOV_EXCLUDE_STOP
 
 impl CheckOrder {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> CheckOrder {
         CheckOrder { last_apath: None }
     }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::backup::BackupOptions;
+use crate::blockhash::BlockHash;
 use crate::copy_tree::CopyOptions;
 use crate::errors::Error;
 use crate::jsonio::{read_json, write_json};
@@ -248,8 +249,8 @@ impl Archive {
     pub fn validate(&self) -> Result<ValidateStats> {
         let mut stats = self.validate_archive_dir()?;
         ui::println("Check blockdir...");
-        let block_lengths: HashMap<String, usize> = self.block_dir.validate(&mut stats)?;
-        self.validate_bands(&block_lengths, &mut stats)?;
+        let block_lens: HashMap<BlockHash, usize> = self.block_dir.validate(&mut stats)?;
+        self.validate_bands(&block_lens, &mut stats)?;
 
         if stats.has_problems() {
             ui::problem("Archive has some problems.");
@@ -324,7 +325,7 @@ impl Archive {
 
     fn validate_bands(
         &self,
-        block_lengths: &HashMap<String, usize>,
+        block_lengths: &HashMap<BlockHash, usize>,
         stats: &mut ValidateStats,
     ) -> Result<()> {
         // TODO: Don't stop early on any errors in the steps below, but do count them.

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -224,7 +224,7 @@ impl Archive {
     }
 
     /// Returns all blocks referenced by all bands.
-    pub fn referenced_blocks(&self) -> Result<BTreeSet<String>> {
+    pub fn referenced_blocks(&self) -> Result<BTreeSet<BlockHash>> {
         let archive = self.clone();
         Ok(self
             .iter_band_ids_unsorted()?
@@ -236,7 +236,7 @@ impl Archive {
     }
 
     /// Returns an iterator of blocks that are present and referenced by no index.
-    pub fn unreferenced_blocks(&self) -> Result<impl Iterator<Item = String>> {
+    pub fn unreferenced_blocks(&self) -> Result<impl Iterator<Item = BlockHash>> {
         ui::println("Find referenced blocks...");
         let referenced = self.referenced_blocks()?;
         ui::println("Find present blocks...");

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -39,10 +39,7 @@ use crate::transport::local::LocalTransport;
 use crate::transport::{DirEntry, ListDirNames, Transport};
 use crate::*;
 
-/// Use the maximum 64-byte hash.
-pub const BLAKE_HASH_SIZE_BYTES: usize = 64;
-
-const BLOCKDIR_FILE_NAME_LEN: usize = BLAKE_HASH_SIZE_BYTES * 2;
+const BLOCKDIR_FILE_NAME_LEN: usize = crate::BLAKE_HASH_SIZE_BYTES * 2;
 
 /// Take this many characters from the block hash to form the subdirectory name.
 const SUBDIR_NAME_CHARS: usize = 3;

--- a/src/blockhash.rs
+++ b/src/blockhash.rs
@@ -1,0 +1,99 @@
+// Conserve backup system.
+// Copyright 2015, 2016, 2017, 2018, 2019, 2020 Martin Pool.
+
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+//! Block hash address type.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::Display;
+use std::str::FromStr;
+
+use serde::Serialize;
+
+use crate::*;
+
+/// The hash of a block of body data.
+///
+/// Stored in memory as compact bytes, but translatable to and from
+/// hex strings.o
+///
+/// ```
+/// use std::str::FromStr;
+/// use conserve::blockhash::BlockHash2;
+///
+/// let hex_hash = concat!(
+///     "00000000000000000000000000000000",
+///     "00000000000000000000000000000000",
+///     "00000000000000000000000000000000",
+///     "00000000000000000000000000000000",);
+/// let hash = BlockHash2::from_str(hex_hash)
+///     .unwrap();
+/// let hash2 = hash.clone();
+/// assert_eq!(hash2.to_string(), hex_hash);
+/// ```
+#[derive(Clone, Serialize)]
+#[serde(into = "String")]
+#[serde(try_from = "&str")]
+pub struct BlockHash2 {
+    /// Binary hash.
+    bin: [u8; BLAKE_HASH_SIZE_BYTES],
+}
+
+#[derive(Debug)]
+pub struct BlockHashParseError {}
+
+impl FromStr for BlockHash2 {
+    type Err = BlockHashParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s.len() != BLAKE_HASH_SIZE_BYTES * 2 {
+            return Err(BlockHashParseError {});
+        }
+        let mut bin = [0; BLAKE_HASH_SIZE_BYTES];
+        hex::decode_to_slice(s, &mut bin)
+            .or(Err(BlockHashParseError {}))
+            .and(Ok(BlockHash2 { bin }))
+    }
+}
+
+impl Display for BlockHash2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.bin[..]))
+    }
+}
+
+impl From<BlockHash2> for String {
+    fn from(hash: BlockHash2) -> String {
+        hex::encode(&hash.bin[..])
+    }
+}
+
+impl Ord for BlockHash2 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.bin.cmp(&other.bin)
+    }
+}
+
+impl PartialOrd for BlockHash2 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.bin.cmp(&other.bin))
+    }
+}
+
+impl PartialEq for BlockHash2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.bin[..] == other.bin[..]
+    }
+}
+
+impl Eq for BlockHash2 {}

--- a/src/blockhash.rs
+++ b/src/blockhash.rs
@@ -16,6 +16,7 @@
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use serde::Serialize;
@@ -97,3 +98,9 @@ impl PartialEq for BlockHash2 {
 }
 
 impl Eq for BlockHash2 {}
+
+impl Hash for BlockHash2 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.bin.hash(state);
+    }
+}

--- a/src/blockhash.rs
+++ b/src/blockhash.rs
@@ -31,14 +31,14 @@ use crate::*;
 ///
 /// ```
 /// use std::str::FromStr;
-/// use conserve::blockhash::BlockHash2;
+/// use conserve::blockhash::BlockHash;
 ///
 /// let hex_hash = concat!(
 ///     "00000000000000000000000000000000",
 ///     "00000000000000000000000000000000",
 ///     "00000000000000000000000000000000",
 ///     "00000000000000000000000000000000",);
-/// let hash = BlockHash2::from_str(hex_hash)
+/// let hash = BlockHash::from_str(hex_hash)
 ///     .unwrap();
 /// let hash2 = hash.clone();
 /// assert_eq!(hash2.to_string(), hex_hash);
@@ -46,7 +46,7 @@ use crate::*;
 #[derive(Clone, Serialize)]
 #[serde(into = "String")]
 #[serde(try_from = "&str")]
-pub struct BlockHash2 {
+pub struct BlockHash {
     /// Binary hash.
     bin: [u8; BLAKE_HASH_SIZE_BYTES],
 }
@@ -54,7 +54,7 @@ pub struct BlockHash2 {
 #[derive(Debug)]
 pub struct BlockHashParseError {}
 
-impl FromStr for BlockHash2 {
+impl FromStr for BlockHash {
     type Err = BlockHashParseError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -64,51 +64,51 @@ impl FromStr for BlockHash2 {
         let mut bin = [0; BLAKE_HASH_SIZE_BYTES];
         hex::decode_to_slice(s, &mut bin)
             .or(Err(BlockHashParseError {}))
-            .and(Ok(BlockHash2 { bin }))
+            .and(Ok(BlockHash { bin }))
     }
 }
 
-impl Display for BlockHash2 {
+impl Display for BlockHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(&self.bin[..]))
     }
 }
 
-impl From<BlockHash2> for String {
-    fn from(hash: BlockHash2) -> String {
+impl From<BlockHash> for String {
+    fn from(hash: BlockHash) -> String {
         hex::encode(&hash.bin[..])
     }
 }
 
-impl From<Blake2bResult> for BlockHash2 {
-    fn from(hash: Blake2bResult) -> BlockHash2 {
+impl From<Blake2bResult> for BlockHash {
+    fn from(hash: Blake2bResult) -> BlockHash {
         let mut bin = [0; BLAKE_HASH_SIZE_BYTES];
         bin.copy_from_slice(hash.as_bytes());
-        BlockHash2 { bin }
+        BlockHash { bin }
     }
 }
 
-impl Ord for BlockHash2 {
+impl Ord for BlockHash {
     fn cmp(&self, other: &Self) -> Ordering {
         self.bin.cmp(&other.bin)
     }
 }
 
-impl PartialOrd for BlockHash2 {
+impl PartialOrd for BlockHash {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.bin.cmp(&other.bin))
     }
 }
 
-impl PartialEq for BlockHash2 {
+impl PartialEq for BlockHash {
     fn eq(&self, other: &Self) -> bool {
         self.bin[..] == other.bin[..]
     }
 }
 
-impl Eq for BlockHash2 {}
+impl Eq for BlockHash {}
 
-impl Hash for BlockHash2 {
+impl Hash for BlockHash {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.bin.hash(state);
     }

--- a/src/blockhash.rs
+++ b/src/blockhash.rs
@@ -19,6 +19,7 @@ use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
+use blake2_rfc::blake2b::Blake2bResult;
 use serde::Serialize;
 
 use crate::*;
@@ -76,6 +77,14 @@ impl Display for BlockHash2 {
 impl From<BlockHash2> for String {
     fn from(hash: BlockHash2) -> String {
         hex::encode(&hash.bin[..])
+    }
+}
+
+impl From<Blake2bResult> for BlockHash2 {
+    fn from(hash: Blake2bResult) -> BlockHash2 {
+        let mut bin = [0; BLAKE_HASH_SIZE_BYTES];
+        bin.copy_from_slice(hash.as_bytes());
+        BlockHash2 { bin }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub use crate::band::Band;
 pub use crate::band::BandSelectionPolicy;
 pub use crate::bandid::BandId;
 pub use crate::blockdir::BlockDir;
+pub use crate::blockhash::BlockHash;
 pub use crate::copy_tree::copy_tree;
 pub use crate::entry::Entry;
 pub use crate::errors::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod backup;
 mod band;
 pub mod bandid;
 mod blockdir;
+pub mod blockhash;
 pub mod compress;
 pub mod copy_tree;
 mod entry;
@@ -91,5 +92,12 @@ const TIMESTAMP_FORMAT: &str = "%F %T";
 
 /// Temporary files in the archive have this prefix.
 const TMP_PREFIX: &str = "tmp";
+
+/// Metadata file in the band directory.
 static BAND_HEAD_FILENAME: &str = "BANDHEAD";
+
+/// Metadata file in the band directory, for closed bands.
 static BAND_TAIL_FILENAME: &str = "BANDTAIL";
+
+/// Length of the binary content hash.
+pub(crate) const BLAKE_HASH_SIZE_BYTES: usize = 64;

--- a/src/stored_tree.rs
+++ b/src/stored_tree.rs
@@ -70,7 +70,7 @@ impl StoredTree {
                     .addrs
                     .iter()
                     .filter(|addr| {
-                        if let Some(block_len) = block_lengths.get(&addr.hash.parse().unwrap()) {
+                        if let Some(block_len) = block_lengths.get(&addr.hash) {
                             // Present, but the address is out of range.
                             if (addr.start + addr.len) > (*block_len as u64) {
                                 ui::problem(&format!(

--- a/src/stored_tree.rs
+++ b/src/stored_tree.rs
@@ -57,7 +57,7 @@ impl StoredTree {
 
     pub fn validate(
         &self,
-        block_lengths: &HashMap<String, usize>,
+        block_lengths: &HashMap<BlockHash, usize>,
         stats: &mut ValidateStats,
     ) -> Result<()> {
         let band_id = self.band().id();
@@ -70,7 +70,7 @@ impl StoredTree {
                     .addrs
                     .iter()
                     .filter(|addr| {
-                        if let Some(block_len) = block_lengths.get(&addr.hash) {
+                        if let Some(block_len) = block_lengths.get(&addr.hash.parse().unwrap()) {
                             // Present, but the address is out of range.
                             if (addr.start + addr.len) > (*block_len as u64) {
                                 ui::problem(&format!(

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -20,9 +20,11 @@ fn unreferenced_blocks() {
     let af = ScratchArchive::new();
     let tf = TreeFixture::new();
     tf.create_file("hello");
-    const CONTENT_HASH: &str =
+    let content_hash: BlockHash =
         "9063990e5c5b2184877f92adace7c801a549b00c39cd7549877f06d5dd0d3a6ca6eee42d5\
-        896bdac64831c8114c55cee664078bd105dc691270c92644ccb2ce7";
+        896bdac64831c8114c55cee664078bd105dc691270c92644ccb2ce7"
+            .parse()
+            .unwrap();
 
     let _copy_stats = af
         .backup(&tf.path(), &BackupOptions::default())
@@ -31,6 +33,6 @@ fn unreferenced_blocks() {
     // Delete the band and index
     std::fs::remove_dir_all(af.path().join("b0000")).unwrap();
 
-    let unreferenced: Vec<String> = af.unreferenced_blocks().unwrap().collect();
-    assert_eq!(unreferenced, [CONTENT_HASH]);
+    let unreferenced: Vec<BlockHash> = af.unreferenced_blocks().unwrap().collect();
+    assert_eq!(unreferenced, [content_hash]);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -163,6 +163,7 @@ fn check_backup(af: &ScratchArchive) {
         af.referenced_blocks()
             .unwrap()
             .into_iter()
+            .map(|h| h.to_string())
             .collect::<Vec<String>>(),
         vec![HELLO_HASH]
     );
@@ -170,6 +171,7 @@ fn check_backup(af: &ScratchArchive) {
         af.block_dir()
             .block_names()
             .unwrap()
+            .map(|h| h.to_string())
             .collect::<Vec<String>>(),
         vec![HELLO_HASH]
     );


### PR DESCRIPTION
Aside from type safety, this should use less memory for cases such as gc and validation where there are many hashes in memory at once.