### PR TITLE
Implement option for 'conserve versions' to sort bands by start time.

### DIFF
--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -146,7 +146,7 @@ enum Command {
         #[structopt(long, short = "q")]
         short: bool,
         /// Sort bands to show most recent first.
-        #[structopt(long, short = "n", conflicts_with = "short" )]
+        #[structopt(long, short = "n")]
         newest: bool,
         /// Show size of stored trees.
         #[structopt(long, short = "z", conflicts_with = "short")]
@@ -363,7 +363,7 @@ impl Command {
                 ui::enable_progress(false);
                 let archive = Archive::open_path(archive)?;
                 if *short {
-                    output::show_brief_version_list(&archive, &mut stdout)?;
+                    output::show_brief_version_list(&archive, *newest, &mut stdout)?;
                 } else {
                     output::show_verbose_version_list(&archive, *newest,*sizes, &mut stdout)?;
                 }

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -145,6 +145,9 @@ enum Command {
         /// Show only version names.
         #[structopt(long, short = "q")]
         short: bool,
+        /// Sort bands to show most recent first.
+        #[structopt(long, short = "n", conflicts_with = "short" )]
+        newest: bool,
         /// Show size of stored trees.
         #[structopt(long, short = "z", conflicts_with = "short")]
         sizes: bool,
@@ -354,6 +357,7 @@ impl Command {
             Command::Versions {
                 archive,
                 short,
+                newest,
                 sizes,
             } => {
                 ui::enable_progress(false);
@@ -361,7 +365,7 @@ impl Command {
                 if *short {
                     output::show_brief_version_list(&archive, &mut stdout)?;
                 } else {
-                    output::show_verbose_version_list(&archive, *sizes, &mut stdout)?;
+                    output::show_verbose_version_list(&archive, *newest,*sizes, &mut stdout)?;
                 }
             }
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -31,9 +31,11 @@ pub fn show_brief_version_list(archive: &Archive, w: &mut dyn Write) -> Result<(
 
 pub fn show_verbose_version_list(
     archive: &Archive,
+    sort_recent_first: bool,
     show_sizes: bool,
     w: &mut dyn Write,
 ) -> Result<()> {
+    let mut band_infos = vec![];
     for band_id in archive.list_band_ids()? {
         let band = match Band::open(&archive, &band_id) {
             Ok(band) => band,
@@ -49,6 +51,14 @@ pub fn show_verbose_version_list(
                 continue;
             }
         };
+        band_infos.push(info);
+    }
+    if sort_recent_first {
+        band_infos.sort_unstable_by_key(|info| std::cmp::Reverse(info.start_time));
+    }
+
+    for info in band_infos {
+        let band_id = &info.id;
         let is_complete_str = if info.is_closed {
             "complete"
         } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -483,3 +483,31 @@ fn size_exclude() {
         .success()
         .stdout("10\n");
 }
+
+#[test]
+fn brief_versions_sort_recent_first() {
+    let af = ScratchArchive::new();
+    af.store_two_versions();
+
+    run_conserve()
+        .args(&["versions", "--short", "--newest"])
+        .arg(af.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout("b0001\nb0000\n");
+}
+
+#[test]
+fn verbose_versions_sort_recent_first() {
+    let af = ScratchArchive::new();
+    af.store_two_versions();
+
+    run_conserve()
+        .args(&["versions", "--newest"])
+        .arg(af.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::is_match("b0001.*\nb0000.*").unwrap());
+}


### PR DESCRIPTION
Parameter '--newest' shows most recent band first.
Fixes sourcefrog/conserve#121