### PR TITLE
Fixed the StitchedIndexHunks iterator for uncompleted archives

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -233,10 +233,7 @@ impl BackupWriter {
         self.stats.files += 1;
         let apath = source_entry.apath();
         let result;
-        if let Some(basis_entry) = self
-            .basis_index
-            .advance_to(apath)
-        {
+        if let Some(basis_entry) = self.basis_index.advance_to(apath) {
             if source_entry.is_unchanged_from(&basis_entry) {
                 self.stats.unmodified_files += 1;
                 self.index_builder.push_entry(basis_entry);

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -151,7 +151,7 @@ struct BackupWriter {
 
     /// The index for the last stored band, used as hints for whether newly
     /// stored files have changed.
-    basis_index: Option<crate::index::IndexEntryIter<crate::stitch::IterStitchedIndexHunks>>,
+    basis_index: crate::index::IndexEntryIter<crate::stitch::IterStitchedIndexHunks>,
 
     file_combiner: FileCombiner,
 }
@@ -164,10 +164,9 @@ impl BackupWriter {
         if gc_lock::GarbageCollectionLock::is_locked(archive)? {
             return Err(Error::GarbageCollectionLockHeld);
         }
-        let basis_index = archive.last_band_id()?.map(|band_id| {
-            IterStitchedIndexHunks::new(archive, &band_id)
-                .iter_entries(Apath::root(), Exclude::nothing())
-        });
+        let basis_index = IterStitchedIndexHunks::new(archive, archive.last_band_id()?)
+            .iter_entries(Apath::root(), Exclude::nothing());
+
         // Create the new band only after finding the basis band!
         let band = Band::create(archive)?;
         let index_builder = band.index_builder();
@@ -236,8 +235,7 @@ impl BackupWriter {
         let result;
         if let Some(basis_entry) = self
             .basis_index
-            .as_mut()
-            .and_then(|bi| bi.advance_to(apath))
+            .advance_to(apath)
         {
             if source_entry.is_unchanged_from(&basis_entry) {
                 self.stats.unmodified_files += 1;

--- a/src/stitch.rs
+++ b/src/stitch.rs
@@ -107,7 +107,7 @@ impl Iterator for IterStitchedIndexHunks {
 
             if let Some(band_id) = &self.band_id {
                 // Start reading this new index and skip forward until after last_apath
-                let mut iter_hunks = Band::open(&self.archive, &band_id)
+                let mut iter_hunks = Band::open(&self.archive, band_id)
                     .expect("Failed to open band")
                     .index()
                     .iter_hunks();

--- a/src/stitch.rs
+++ b/src/stitch.rs
@@ -95,11 +95,11 @@ impl Iterator for IterStitchedIndexHunks {
 
                 let band_id = self.band_id.take().expect("last band id should be present");
                 if self.archive.band_is_closed(&band_id).unwrap_or(false) {
-                    // We reached the end of a complete index in this band, 
+                    // We reached the end of a complete index in this band,
                     // so there's no need to look at any earlier bands, and we're done iterating.
                     return None;
                 }
-                
+
                 // self.band_id might be None afterwards, if there is no previous band.
                 // If so, we're done.
                 self.band_id = previous_existing_band(&self.archive, &band_id);
@@ -267,18 +267,15 @@ mod test {
 
         let lt = tf.live_tree();
         let af = ScratchArchive::new();
-        backup(&af, &lt, &BackupOptions::default())
-            .expect("backup should work");
+        backup(&af, &lt, &BackupOptions::default()).expect("backup should work");
 
         af.transport().remove_file("b0000/BANDTAIL").unwrap();
-        let band_ids = af.list_band_ids()
-            .expect("should list bands");
-            
-        let band_id = band_ids.first()
-            .expect("expected at least one band");
+        let band_ids = af.list_band_ids().expect("should list bands");
+
+        let band_id = band_ids.first().expect("expected at least one band");
 
         let mut iter = IterStitchedIndexHunks::new(&af, Some(band_id.clone()));
-        // Get the first and only index entry. 
+        // Get the first and only index entry.
         // `index_hunks` and `band_id` should be `Some`.
         assert!(iter.next().is_some());
 

--- a/src/stitch.rs
+++ b/src/stitch.rs
@@ -156,7 +156,7 @@ mod test {
     }
 
     fn simple_ls(archive: &Archive, band_id: &BandId) -> String {
-        let strs: Vec<String> = IterStitchedIndexHunks::new(archive, band_id)
+        let strs: Vec<String> = IterStitchedIndexHunks::new(archive, Some(band_id.clone()))
             .flatten()
             .map(|entry| format!("{}:{}", &entry.apath, entry.target.unwrap()))
             .collect();

--- a/src/stitch.rs
+++ b/src/stitch.rs
@@ -86,6 +86,8 @@ impl Iterator for IterStitchedIndexHunks {
                         return Some(hunk);
                     } // otherwise, empty, try the next
                 }
+                /* We iterated through any know entry. */
+                self.index_hunks = None;
 
                 let band_id = self.band_id.take().expect("last band id should be present");
                 if self.archive.band_is_closed(&band_id).unwrap_or(false) {
@@ -97,11 +99,9 @@ impl Iterator for IterStitchedIndexHunks {
                     return None;
                 }
                 
-                self.index_hunks = None;
-                self.band_id = previous_existing_band(&self.archive, &band_id);
-
-                // self.band_id might be None, if there is no previous band.
+                // self.band_id might be None afterwards, if there is no previous band.
                 // If so, we're done.
+                self.band_id = previous_existing_band(&self.archive, &band_id);
             }
 
             if let Some(band_id) = &self.band_id {

--- a/src/stitch.rs
+++ b/src/stitch.rs
@@ -55,10 +55,10 @@ impl IterStitchedIndexHunks {
     /// the same point in the previous band, continuing backwards recursively
     /// until either there are no more previous indexes, or a complete index
     /// is found.
-    pub(crate) fn new(archive: &Archive, band_id: &BandId) -> IterStitchedIndexHunks {
+    pub(crate) fn new(archive: &Archive, band_id: Option<BandId>) -> IterStitchedIndexHunks {
         IterStitchedIndexHunks {
             archive: archive.clone(),
-            band_id: Some(band_id.clone()),
+            band_id,
             last_apath: None,
             index_hunks: None,
         }

--- a/src/stored_tree.rs
+++ b/src/stored_tree.rs
@@ -60,8 +60,10 @@ impl ReadTree for StoredTree {
 
     /// Return an iter of index entries in this stored tree.
     fn iter_entries(&self, subtree: Apath, exclude: Exclude) -> Result<Self::IT> {
-        Ok(IterStitchedIndexHunks::new(&self.archive, Some(self.band.id().clone()))
-            .iter_entries(subtree, exclude))
+        Ok(
+            IterStitchedIndexHunks::new(&self.archive, Some(self.band.id().clone()))
+                .iter_entries(subtree, exclude),
+        )
     }
 
     fn file_contents(&self, entry: &Self::Entry) -> Result<Self::R> {

--- a/src/stored_tree.rs
+++ b/src/stored_tree.rs
@@ -60,7 +60,7 @@ impl ReadTree for StoredTree {
 
     /// Return an iter of index entries in this stored tree.
     fn iter_entries(&self, subtree: Apath, exclude: Exclude) -> Result<Self::IT> {
-        Ok(IterStitchedIndexHunks::new(&self.archive, self.band.id())
+        Ok(IterStitchedIndexHunks::new(&self.archive, Some(self.band.id().clone()))
             .iter_entries(subtree, exclude))
     }
 


### PR DESCRIPTION
Hey,  
I actually found a bug which this PR fixes.  
  
Description:  
When creating a new archive and creating one unfinished back-up (e. g. backing up half the files) the next backup will be painfully slow for new (not previously back upped) files.  
  
Solution:  
I tracked the issue down to the `IterStitchedIndexHunks` implementation.  
The old implementation would load the first bands (in the archive) index over and over again for every file which will be backed up. This is because if there because if there is no previous backup the iterator will try to load the index of the current band on every second call.  
  
This PR fixes this.  