### PR TITLE
Clean up Transport API

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,2 +1,6 @@
+exclude_re = [
+    # Causes a loop because every file seems to exist...
+    "Error::is_not_found -> bool with false",
+]
 # Include only files that are currently well-tested.
-examine_globs = ["src/bandid.rs", "src/bin/conserve.rs"]
+examine_globs = ["src/bandid.rs", "src/bin/conserve.rs", "src/transport.rs"]

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -23,7 +23,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
-use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -41,7 +40,6 @@ use crate::blockhash::BlockHash;
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::progress::{Bar, Progress};
 use crate::stats::Sizes;
-use crate::transport::local::LocalTransport;
 use crate::transport::{ListDir, Transport};
 use crate::*;
 
@@ -86,10 +84,6 @@ fn block_relpath(hash: &BlockHash) -> String {
 }
 
 impl BlockDir {
-    pub fn open_path(path: &Path) -> BlockDir {
-        BlockDir::open(Box::new(LocalTransport::new(path)))
-    }
-
     pub fn open(transport: Box<dyn Transport>) -> BlockDir {
         BlockDir {
             transport: Arc::from(transport),

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -84,17 +84,13 @@ fn block_relpath(hash: &BlockHash) -> String {
 }
 
 impl BlockDir {
-    pub fn open(transport: Box<dyn Transport>) -> BlockDir {
-        BlockDir {
-            transport: Arc::from(transport),
-        }
+    pub fn open(transport: Arc<dyn Transport>) -> BlockDir {
+        BlockDir { transport }
     }
 
-    pub fn create(transport: Box<dyn Transport>) -> Result<BlockDir> {
+    pub fn create(transport: Arc<dyn Transport>) -> Result<BlockDir> {
         transport.create_dir("")?;
-        Ok(BlockDir {
-            transport: Arc::from(transport),
-        })
+        Ok(BlockDir { transport })
     }
 
     /// Returns the number of compressed bytes.

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -96,11 +96,6 @@ impl BlockDir {
         }
     }
 
-    /// Create a BlockDir directory and return an object accessing it.
-    pub fn create_path(path: &Path) -> Result<BlockDir> {
-        BlockDir::create(Box::new(LocalTransport::new(path)))
-    }
-
     pub fn create(transport: Box<dyn Transport>) -> Result<BlockDir> {
         transport.create_dir("")?;
         Ok(BlockDir {

--- a/src/index.rs
+++ b/src/index.rs
@@ -201,9 +201,9 @@ pub struct IndexWriter {
 /// Accumulate and write out index entries into files in an index directory.
 impl IndexWriter {
     /// Make a new builder that will write files into the given directory.
-    pub fn new(transport: Box<dyn Transport>) -> IndexWriter {
+    pub fn new(transport: Arc<dyn Transport>) -> IndexWriter {
         IndexWriter {
-            transport: Arc::from(transport),
+            transport,
             entries: Vec::<IndexEntry>::with_capacity(MAX_ENTRIES_PER_HUNK),
             sequence: 0,
             check_order: apath::DebugCheckOrder::new(),
@@ -285,13 +285,11 @@ pub struct IndexRead {
 impl IndexRead {
     #[allow(unused)]
     pub(crate) fn open_path(path: &Path) -> IndexRead {
-        IndexRead::open(Box::new(LocalTransport::new(path)))
+        IndexRead::open(Arc::new(LocalTransport::new(path)))
     }
 
-    pub(crate) fn open(transport: Box<dyn Transport>) -> IndexRead {
-        IndexRead {
-            transport: Arc::from(transport),
-        }
+    pub(crate) fn open(transport: Arc<dyn Transport>) -> IndexRead {
+        IndexRead { transport }
     }
 
     /// Return the (1-based) number of index hunks in an index directory.
@@ -536,7 +534,7 @@ mod tests {
 
     fn setup() -> (TempDir, IndexWriter) {
         let testdir = TempDir::new().unwrap();
-        let ib = IndexWriter::new(Box::new(LocalTransport::new(testdir.path())));
+        let ib = IndexWriter::new(Arc::new(LocalTransport::new(testdir.path())));
         (testdir, ib)
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -97,6 +97,9 @@ pub trait Transport: Send + Sync + std::fmt::Debug {
     /// the complete content. On a local filesystem the content is written to a temporary file and
     /// then renamed.
     ///
+    /// If the file already exists, this should return an [Error] with kind
+    /// [ErrorKind::AlreadyExists].
+    ///
     /// If a temporary file is used, the name should start with `crate::TMP_PREFIX`.
     fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()>;
 
@@ -149,7 +152,7 @@ pub struct Error {
     kind: ErrorKind,
     /// The underlying error: for example an IO or S3 error.
     source: Option<Box<dyn error::Error + Send + Sync>>,
-    /// The affected path.
+    /// The affected path, possibly relative to the transport.
     path: Option<String>,
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -146,7 +146,7 @@ pub struct ListDir {
 #[derive(Debug)]
 pub struct Error {
     /// What type of generally known error?
-    pub kind: ErrorKind,
+    kind: ErrorKind,
     /// The underlying error: for example an IO or S3 error.
     source: Option<Box<dyn error::Error + Send + Sync>>,
     /// The affected path.
@@ -158,10 +158,13 @@ pub struct Error {
 pub enum ErrorKind {
     #[display(fmt = "Not found")]
     NotFound,
+
     #[display(fmt = "Already exists")]
     AlreadyExists,
+
     #[display(fmt = "Permission denied")]
     PermissionDenied,
+
     #[display(fmt = "Other transport error")]
     Other,
 }
@@ -187,6 +190,11 @@ impl Error {
 
     pub fn is_not_found(&self) -> bool {
         self.kind == ErrorKind::NotFound
+    }
+
+    /// The transport-relative path where this error occurred, if known.
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
     }
 }
 

--- a/src/transport/local.rs
+++ b/src/transport/local.rs
@@ -17,6 +17,7 @@ use std::fs::{create_dir, File};
 use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use bytes::Bytes;
 use metrics::{counter, increment_counter};
@@ -143,8 +144,8 @@ impl Transport for LocalTransport {
         std::fs::remove_dir_all(&path).map_err(|err| super::Error::io_error(&path, err))
     }
 
-    fn sub_transport(&self, relpath: &str) -> Box<dyn Transport> {
-        Box::new(LocalTransport {
+    fn sub_transport(&self, relpath: &str) -> Arc<dyn Transport> {
+        Arc::new(LocalTransport {
             root: self.root.join(relpath),
         })
     }


### PR DESCRIPTION
- rm unused BlockDir::create_path
- rm BlockDir::open_path
- Pass around Arc<dyn Transport> rather than Box
- `transport::Error::source` is now a boxed `Error`
- `transports.rs` is now mutants-clean