### PR TITLE
Load timezone before starting threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
@@ -1526,9 +1526,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ snap = "1.0.0"
 tempfile = "3"
 thiserror = "1.0.19"
 thousands = "0.2.0"
-time = { version = "0.3", features = [
+time = { version = "0.3.28", features = [
     "local-offset",
     "serde",
     "serde-human-readable",

--- a/src/show.rs
+++ b/src/show.rs
@@ -39,8 +39,8 @@ pub struct ShowVersionsOptions {
     pub start_time: bool,
     /// Show how much time the backup took, or "incomplete" if it never finished.
     pub backup_duration: bool,
-    /// Show times in UTC rather than the local timezone.
-    pub utc: bool,
+    /// Show times in this zone.
+    pub timezone: Option<UtcOffset>,
 }
 
 /// Print a list of versions, one per line.
@@ -53,7 +53,6 @@ pub fn show_versions(
     if options.newest_first {
         band_ids.reverse();
     }
-    let local_offset = UtcOffset::current_local_offset().expect("get local time offset");
     for band_id in band_ids {
         if !(options.tree_size || options.start_time || options.backup_duration) {
             writeln!(w, "{band_id}")?;
@@ -78,8 +77,8 @@ pub fn show_versions(
 
         if options.start_time {
             let mut start_time = info.start_time;
-            if !options.utc {
-                start_time = start_time.to_offset(local_offset);
+            if let Some(timezone) = options.timezone {
+                start_time = start_time.to_offset(timezone);
             }
             l.push(format!(
                 "{date:<25}", // "yyyy-mm-ddThh:mm:ss+oooo" => 25


### PR DESCRIPTION
time-rs now errors out if you try to get the local timezone after
multiple threads have started, because of a risk that one of them might
simultaneously mutate the environment. So, load and remember it early
in main.

Give ShowVersionOptions a timezone offset rather than just a `utc`
bool.
