### PR TITLE
Find index hunks by listing directories

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,6 +1,5 @@
-exclude_re = [
-    # Causes a loop because every file seems to exist...
-    "Error::is_not_found -> bool with false",
-]
+# Controls tests with `cargo mutants`
+
+exclude_re = []
 # Include only files that are currently well-tested.
 examine_globs = ["src/bandid.rs", "src/bin/conserve.rs", "src/transport.rs"]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -2,4 +2,9 @@
 
 exclude_re = []
 # Include only files that are currently well-tested.
-examine_globs = ["src/bandid.rs", "src/bin/conserve.rs", "src/transport.rs"]
+examine_globs = [
+    "src/bandid.rs",
+    "src/bin/conserve.rs",
+    "src/transport.rs",
+    "src/transport/local.rs",
+]

--- a/src/live_tree.rs
+++ b/src/live_tree.rs
@@ -66,15 +66,6 @@ impl tree::ReadTree for LiveTree {
     fn iter_entries(&self, subtree: Apath, exclude: Exclude) -> Result<Self::IT> {
         Iter::new(&self.path, subtree, exclude)
     }
-
-    fn estimate_count(&self) -> Result<u64> {
-        // TODO: This stats the file and builds an entry about them, just to
-        // throw it away. We could perhaps change the iter to optionally do
-        // less work.
-        Ok(self
-            .iter_entries(Apath::root(), Exclude::nothing())?
-            .count() as u64)
-    }
 }
 
 fn entry_from_fs_metadata(

--- a/src/stored_tree.rs
+++ b/src/stored_tree.rs
@@ -67,10 +67,6 @@ impl ReadTree for StoredTree {
                 .iter_entries(subtree, exclude),
         )
     }
-
-    fn estimate_count(&self) -> Result<u64> {
-        self.band.index().estimate_entry_count()
-    }
 }
 
 #[cfg(test)]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -31,10 +31,6 @@ pub trait ReadTree {
     /// iterator.
     fn iter_entries(&self, subtree: Apath, exclude: Exclude) -> Result<Self::IT>;
 
-    /// Estimate the number of entries in the tree.
-    /// This might do somewhat expensive IO, so isn't the Iter's `size_hint`.
-    fn estimate_count(&self) -> Result<u64>;
-
     /// Measure the tree size.
     ///
     /// This typically requires walking all entries, which may take a while.


### PR DESCRIPTION
- Remove estimate_count
- Find index hunks by listing directories, not repeated probing
- is_not_found is now well-tested! so all of `transport.rs` and `transport/local.rs` is well tested
