### PR TITLE
Install cargo-mutants using install-action in CI (much faster)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
   cargo-mutants:
     runs-on: ubuntu-latest
     # Don't run expensive mutant tests until we know the build is clean.
-    needs: tests
+    needs: [tests, pr-mutants]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,8 +65,10 @@ jobs:
     needs: [pr-mutants]
     # Don't run expensive mutant tests until we know the build is clean.
     strategy:
+      # We want to see all the missed mutants so don't fail fast.
+      fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,7 +86,7 @@ jobs:
         # testing.
         run: >
           cargo mutants --no-shuffle -vV --cargo-arg --no-default-features
-          --shard ${{ matrix.shard }}/8
+          --shard ${{ matrix.shard }}/4
       - name: Archive results
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,10 +65,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install cargo-mutants
-        uses: baptiste0928/cargo-install@v2
+      - uses: taiki-e/install-action@v2
+        name: Install cargo-mutants using install-action
         with:
-          crate: cargo-mutants
+          tool: cargo-mutants
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -100,10 +100,14 @@ jobs:
         with:
           toolchain: beta
       - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-mutants
-        uses: baptiste0928/cargo-install@v2
+      - uses: taiki-e/install-action@v2
+        name: Install cargo-mutants using install-action
         with:
-          crate: cargo-mutants
+          tool: cargo-mutants
+      # - name: Install cargo-mutants
+      #   uses: baptiste0928/cargo-install@v2
+      #   with:
+      #     crate: cargo-mutants
       - name: Mutants
         run: |
           cargo mutants --no-shuffle -vV --in-diff git.diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,10 +77,10 @@ jobs:
         # Can't use --all-features here because BLAKE2 SIMD needs unstable...
         # Don't use the S3 features because they require AWS credentials for realistic
         # testing.
-        run:
-          cargo mutants -j2 --no-shuffle -vV --cargo-arg --no-default-features
+        run: cargo mutants --no-shuffle -vV --cargo-arg --no-default-features
       - name: Archive results
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: mutation-report
           path: mutants.out

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,10 @@ jobs:
         with:
           toolchain: beta
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-mutants
+      - name: Install cargo-mutants
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-mutants
       - name: Mutants
         run: |
           cargo mutants --no-shuffle -vV --in-diff git.diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,8 +60,9 @@ jobs:
 
   cargo-mutants:
     runs-on: ubuntu-latest
-    # Don't run expensive mutant tests until we know the build is clean.
-    needs: [tests, pr-mutants]
+    # Don't run expensive mutant tests until we know the build is clean, and recently
+    # touched code is clean.
+    needs: [pr-mutants]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -104,10 +105,6 @@ jobs:
         name: Install cargo-mutants using install-action
         with:
           tool: cargo-mutants
-      # - name: Install cargo-mutants
-      #   uses: baptiste0928/cargo-install@v2
-      #   with:
-      #     crate: cargo-mutants
       - name: Mutants
         run: |
           cargo mutants --no-shuffle -vV --in-diff git.diff


### PR DESCRIPTION
- [x] Always archive mutants.out
- [x] Run full mutants only after pr-mutants
- [x] Install using install-action: pulls a binary from GitHub, much faster
- [x] Shard full mutants using the newly released feature