### PR TITLE
More test coverage for mutants

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,11 +49,6 @@ jobs:
         run: >
           cargo test --no-default-features --features=${{ matrix.features }}
           --features fail/failpoints -- --include-ignored
-      # Clippy and rustfmt are excellent tools but are turned off here because it's too
-      # easy for PRs to fail due to irrelevant changes including Clippy flagging problems
-      # that it did not notice before.
-      # - name: clippy
-      #   run: cargo clippy --all-targets -- -d clippy::all
 
   # Run rustfmt separately so that it does not block test results
   rustfmt:
@@ -67,6 +62,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: rustfmt check
         run: cargo fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: clippy
+        run: cargo clippy --all-targets -- --deny clippy::all
 
   cargo-mutants:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,13 +42,13 @@ jobs:
           cargo --version
           rustc --version
       - name: Build
-        run:
+        run: >
           cargo build --all-targets --no-default-features --features=${{
-          matrix.features }}
+          matrix.features }} --features fail/failpoints
       - name: Test
-        run:
-          cargo test --no-default-features --features=${{ matrix.features }} --
-          --include-ignored
+        run: >
+          cargo test --no-default-features --features=${{ matrix.features }}
+          --features fail/failpoints -- --include-ignored
       # Clippy and rustfmt are excellent tools but are turned off here because it's too
       # easy for PRs to fail due to irrelevant changes including Clippy flagging problems
       # that it did not notice before.
@@ -96,7 +96,7 @@ jobs:
         # testing.
         run: >
           cargo mutants --no-shuffle -vV --cargo-arg --no-default-features
-          --shard ${{ matrix.shard }}/4
+          --shard ${{ matrix.shard }}/4 -- --features fail/failpoints
       - name: Archive results
         uses: actions/upload-artifact@v3
         if: always()
@@ -125,7 +125,8 @@ jobs:
           tool: cargo-mutants
       - name: Mutants in diff
         run: >
-          cargo mutants --no-shuffle -vV --in-diff git.diff
+          cargo mutants --no-shuffle -vV --in-diff git.diff -- --features
+          fail/failpoints
       - name: Archive mutants.out
         uses: actions/upload-artifact@v3
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "crc32c",
  "derive_more",
  "dir-assert",
+ "fail",
  "filetime",
  "futures",
  "globset",
@@ -984,6 +985,17 @@ checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ cachedir = "0.3"
 clicolors-control = "1.0"
 crc32c = { version = "0.6", optional = true }
 derive_more = "0.99"
+fail = "0.5.1"
 filetime = "0.2"
 futures = { version = "0.3", optional = true }
 globset = "0.4.5"
@@ -110,3 +111,7 @@ doctest = false
 
 [profile.release]
 debug = true
+
+[[test]]
+name = "failpoints"
+required-features = ["fail/failpoints"]

--- a/doc/design.md
+++ b/doc/design.md
@@ -165,9 +165,7 @@ The library should support several modes of UI:
 1. Primarily, the text UI presented by the `conserve` binary, on a terminal that
    allows cursor control.
 
-In this case the terminal is inherently a global singleton across the process,
-and all the different uses need to be coordinated. Most importantly, log output
-must interleave with progress bars.
+   In this case the terminal is inherently a global singleton across the process, and all the different uses need to be coordinated. Most importantly, log output must interleave with progress bars.
 
 2. Noninteractive text output, when there is no terminal. This should be similar
    to the terminal, but with progress bars and interactive input turned off.

--- a/doc/design.md
+++ b/doc/design.md
@@ -180,10 +180,8 @@ The library should support several modes of UI:
    in a limited way. (Tests that run the `conserve` binary as a subprocess have
    more freedom, including running it on a pseudoterminal.)
 
-This is not implemented yet, but Conserve should migrate to using Rust's
-(fairly) standard `log` crate. Listeners for logs can be configured only
-globally and only once. There should be an option to write logs to a file, as
-well as to the terminal, and at a different level of detail. This implies:
+Conserve writes messages to Rust's widely-used `tracing` crate. Logs can be written to a file with `--log-json`.
+well as to the terminal, and at a different level of detail.
 
 - The library will emit logs but will not by default configure any log targets,
   so that applications can choose the target they want.

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -483,9 +483,6 @@ impl Command {
                         &changes_json.as_deref(),
                     )?,
                 };
-                if *verbose || *long_listing {
-                    // todo!("Disable progress bar");
-                }
                 let stats = restore(&archive, destination, &options, monitor)?;
                 debug!("Restore complete");
                 if !no_stats {

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -517,7 +517,7 @@ impl Command {
                     skip_block_hashes: *quick,
                 };
                 Archive::open(open_transport(archive)?)?.validate(&options, monitor)?;
-                if global_error_count() > 0 || global_warn_count() > 0 {
+                if global_error_count() != 0 || global_warn_count() != 0 {
                     warn!("Archive has some problems.");
                 } else {
                     info!("Archive is OK.");
@@ -643,11 +643,11 @@ fn main() -> Result<ExitCode> {
     match result {
         Err(err) => {
             error!("{err:#}");
-            debug!(error_count, warn_count,);
+            debug!(error_count, warn_count);
             Ok(ExitCode::Failure)
         }
-        Ok(ExitCode::Success) if error_count > 0 || warn_count > 0 => {
-            debug!(error_count, warn_count,);
+        Ok(ExitCode::Success) if error_count != 0 || warn_count != 0 => {
+            debug!(error_count, warn_count);
             Ok(ExitCode::NonFatalErrors)
         }
         Ok(exit_code) => Ok(exit_code),

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -42,7 +42,7 @@ use crate::monitor::Monitor;
 use crate::transport::{ListDir, Transport};
 use crate::*;
 
-const BLOCKDIR_FILE_NAME_LEN: usize = crate::BLAKE_HASH_SIZE_BYTES * 2;
+// const BLOCKDIR_FILE_NAME_LEN: usize = crate::BLAKE_HASH_SIZE_BYTES * 2;
 
 /// Take this many characters from the block hash to form the subdirectory name.
 const SUBDIR_NAME_CHARS: usize = 3;
@@ -290,8 +290,8 @@ impl BlockDir {
                 iter_or.ok()
             })
             .flat_map(|ListDir { files, .. }| files)
-            .filter(|name| name.len() == BLOCKDIR_FILE_NAME_LEN && !name.starts_with(TMP_PREFIX))
-            .filter_map(|name| name.parse().ok()))
+            .filter_map(|name| // drop any invalid names, including temp files
+                name.parse().ok()))
     }
 
     /// Check format invariants of the BlockDir.

--- a/src/change.rs
+++ b/src/change.rs
@@ -111,6 +111,10 @@ impl<E> Change<E> {
         matches!(self, Change::Unchanged { .. })
     }
 
+    pub fn is_changed(&self) -> bool {
+        matches!(self, Change::Changed { .. })
+    }
+
     /// Return the primary metadata: the new version, unless this entry was
     /// deleted in which case the old version.
     pub fn primary_metadata(&self) -> &E {

--- a/src/change.rs
+++ b/src/change.rs
@@ -29,10 +29,6 @@ pub struct EntryChange {
 }
 
 impl EntryChange {
-    pub fn is_unchanged(&self) -> bool {
-        self.change.is_unchanged()
-    }
-
     pub(crate) fn diff_metadata<AE: EntryTrait, BE: EntryTrait>(a: &AE, b: &BE) -> Self {
         debug_assert_eq!(a.apath(), b.apath());
         let ak = a.kind();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -53,5 +53,5 @@ pub fn diff(
         .readahead(readahead);
     Ok(MergeTrees::new(ait, bit)
         .map(|me| me.to_entry_change())
-        .filter(move |c: &EntryChange| include_unchanged || !c.is_unchanged()))
+        .filter(move |c: &EntryChange| include_unchanged || !c.change.is_unchanged()))
 }

--- a/src/termui/monitor.rs
+++ b/src/termui/monitor.rs
@@ -110,6 +110,7 @@ impl Monitor for TermUiMonitor {
     }
 
     fn problem(&self, problem: Problem) {
+        // TODO: Colorful styling; maybe also send it to trace??
         self.view.message(format!("Problem: {:?}", problem));
     }
 

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -207,7 +207,7 @@ where
 ///
 /// Panics if there is no such group, or if the list of groups can't be retrieved,
 /// which is always the case on macOS.
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub fn arbitrary_secondary_group() -> u32 {
     let groups = nix::unistd::getgroups().expect("getgroups");
     let primary_group = nix::unistd::getgid();
@@ -220,7 +220,7 @@ pub fn arbitrary_secondary_group() -> u32 {
 
 #[cfg(test)]
 mod test {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn arbitrary_secondary_group_is_found() {
         let gid = super::arbitrary_secondary_group();

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -201,3 +201,29 @@ where
         .map(|entry| entry.apath().clone().into())
         .collect()
 }
+
+/// On Unix, return the gid of a group that the current user is a member of
+/// and that is not the primary group. This can be used to test chgrp operations.
+///
+/// Panics if there is no such group, or if the list of groups can't be retrieved,
+/// which is always the case on macOS.
+#[cfg(unix)]
+pub fn arbitrary_secondary_group() -> u32 {
+    let groups = nix::unistd::getgroups().expect("getgroups");
+    let primary_group = nix::unistd::getgid();
+    let secondary_group = groups
+        .iter()
+        .find(|gid| **gid != primary_group)
+        .expect("secondary group");
+    secondary_group.as_raw()
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(unix)]
+    #[test]
+    fn arbitrary_secondary_group_is_found() {
+        let gid = super::arbitrary_secondary_group();
+        assert!(gid > 0);
+    }
+}

--- a/tests/api/diff.rs
+++ b/tests/api/diff.rs
@@ -49,9 +49,11 @@ fn diff_unchanged() {
     dbg!(&changes);
     assert_eq!(changes.len(), 2); // Root directory and the file "/thing".
     assert_eq!(changes[0].apath, "/");
-    assert!(changes[0].is_unchanged());
+    assert!(changes[0].change.is_unchanged());
+    assert!(!changes[0].change.is_changed());
     assert_eq!(changes[1].apath, "/thing");
-    assert!(changes[1].is_unchanged());
+    assert!(changes[1].change.is_unchanged());
+    assert!(!changes[1].change.is_changed());
 
     // Excluding unchanged elements
     let options = DiffOptions {
@@ -83,6 +85,7 @@ fn mtime_only_change_reported_as_changed() {
     assert_eq!(changes.len(), 1);
     assert_eq!(changes[0].apath, "/thing");
     assert!(changes[0].change.is_changed());
+    assert!(!changes[0].change.is_unchanged());
 }
 
 // Test only on Linux, as macOS doesn't seem to have a way to get all groups
@@ -113,4 +116,5 @@ fn chgrp_reported_as_changed() {
     assert_eq!(changes.len(), 1);
     assert_eq!(changes[0].apath, "/thing");
     assert!(changes[0].change.is_changed());
+    assert!(!changes[0].change.is_unchanged());
 }

--- a/tests/api/diff.rs
+++ b/tests/api/diff.rs
@@ -85,7 +85,9 @@ fn mtime_only_change_reported_as_changed() {
     assert!(changes[0].change.is_changed());
 }
 
-#[cfg(unix)]
+// Test only on Linux, as macOS doesn't seem to have a way to get all groups
+// (see https://docs.rs/nix/latest/nix/unistd/fn.getgroups.html).
+#[cfg(target_os = "linux")]
 #[test]
 fn chgrp_reported_as_changed() {
     use std::os::unix::fs::chown;

--- a/tests/failpoints/main.rs
+++ b/tests/failpoints/main.rs
@@ -1,0 +1,5 @@
+// Copyright 2024 Martin Pool
+
+//! Tests based on failpoints, simulating IO errors.
+
+mod restore;

--- a/tests/failpoints/restore.rs
+++ b/tests/failpoints/restore.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 Martin Pool
+
+//! Simulate IO errors during restore.
+
+use std::path::Path;
+
+use assert_fs::TempDir;
+use conserve::monitor::collect::CollectMonitor;
+use conserve::transport::open_local_transport;
+use fail::FailScenario;
+
+use conserve::*;
+
+#[test]
+fn create_dir_permission_denied() {
+    let scenario = FailScenario::setup();
+    fail::cfg("conserve::restore::create-dir", "return").unwrap();
+    let archive =
+        Archive::open(open_local_transport(Path::new("testdata/archive/simple/v0.6.10")).unwrap())
+            .unwrap();
+    let options = RestoreOptions {
+        ..RestoreOptions::default()
+    };
+    let restore_tmp = TempDir::new().unwrap();
+    let monitor = CollectMonitor::arc();
+    let stats = restore(&archive, restore_tmp.path(), &options, monitor.clone()).expect("Restore");
+    dbg!(&stats);
+    dbg!(&monitor.problems.lock().unwrap());
+    assert_eq!(stats.errors, 3);
+    // TODO: Check that the monitor saw the errors too, once that's hooked up.
+    scenario.teardown();
+}


### PR DESCRIPTION
- Remove no-op code
- Test tempfiles in blockdir are ignored
- Remove redundant check
- Start using failpoints to exercise error handling code