### PR TITLE
Move away blake2 simd feature

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -53,7 +53,6 @@ jobs:
           toolchain: stable
       - uses: swatinem/rust-cache@v2
       - name: Run mutant tests
-        # Can't use --all-features here because BLAKE2 SIMD needs unstable...
         # Don't use the S3 features because they require AWS credentials for realistic
         # testing.
         run: >

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,9 +77,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
       - name: clippy
         run: cargo clippy --all-targets -- --deny clippy::all
+
+  # Not all features can be run: s3 integration tests require credentials.
+  # But all of them should compile.
+  check-all-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: swatinem/rust-cache@v2
+      - name: clippy
+        run: cargo clippy --all-targets --all-features -- --deny clippy::all
 
   pr-mutants:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,8 @@ tracing-test = { version = "0.2", features = ["no-env-filter"] }
 
 [features]
 # default = ["s3"]
-blake2_simd_asm = ["blake2-rfc/simd_asm"]
+# blake2-rfc/simd_asm needs nightly, so it's no longer a feature here so that --all-features works on stable.
+# blake2_simd_asm = ["blake2-rfc/simd_asm"]
 s3 = [
     "dep:aws-config",
     "dep:aws-sdk-s3",

--- a/README.md
+++ b/README.md
@@ -141,10 +141,9 @@ To install from a git checkout, run
 
 [rust]: https://rustup.rs/
 
-On nightly Rust only, you can enable a potential speed-up to the blake2 hashes
-with
+On nightly Rust only, and only on x86_64, you can enable a slight speed-up with
 
-    cargo +nightly install -f --path . --features blake2_simd_asm
+    cargo +nightly install -f --path . --features blake2-rfc/simd_asm
 
 ### Arch Linux
 


### PR DESCRIPTION
It can still be turned on through blake2-rfc/simd_asm, but since it doesn't build on stable, nor apparently on Apple arm, let's not put it in all_features