### PR TITLE
Fix `restore --only` failing because of missing parent directories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fixed: `restore --only` specifying a subdirectory no longer fails due to parent directories missing from the destination.
+
+- Fixed: More detail about the causes of errors in the log.
+
 - `restore` no longer prints stats, due to internal changes; this will be restored later.
 
 - Minimum Rust version increased to 1.74 due to updated dependencies.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,7 +38,7 @@ pub enum Error {
         referenced_len: usize,
     },
 
-    #[error("Failed to list blocks")]
+    #[error("Failed to list blocks: {source}")]
     ListBlocks {
         #[source]
         source: transport::Error,
@@ -102,14 +102,14 @@ pub enum Error {
         source: globset::Error,
     },
 
-    #[error("Failed to deserialize json from {:?}", path)]
+    #[error("Failed to deserialize json from {path:?}: {source}")]
     DeserializeJson {
         path: String,
         #[source]
         source: serde_json::Error,
     },
 
-    #[error("Failed to serialize json")]
+    #[error("Failed to serialize json: {source}")]
     SerializeJson {
         #[from]
         source: serde_json::Error,
@@ -121,10 +121,10 @@ pub enum Error {
     #[error("Band not found: {band_id}")]
     BandNotFound { band_id: BandId },
 
-    #[error("Failed to list bands")]
+    #[error("Failed to list bands: {source}")]
     ListBands { source: io::Error },
 
-    #[error("Failed to read source file {:?}", path)]
+    #[error("Failed to read source file {path:?}: {source}")]
     ReadSourceFile { path: PathBuf, source: io::Error },
 
     #[error("Unsupported source file kind: {path:?}")]
@@ -133,32 +133,32 @@ pub enum Error {
     #[error("Unsupported symlink encoding: {path:?}")]
     UnsupportedTargetEncoding { path: PathBuf },
 
-    #[error("Failed to read source tree {:?}", path)]
+    #[error("Failed to read source tree {path:?}: {source}")]
     ListSourceTree { path: PathBuf, source: io::Error },
 
-    #[error("Failed to restore file {:?}", path)]
+    #[error("Failed to restore file {path:?}: {source}")]
     RestoreFile { path: PathBuf, source: io::Error },
 
-    #[error("Failed to restore symlink {path:?}")]
+    #[error("Failed to restore symlink {path:?}: {source}")]
     RestoreSymlink { path: PathBuf, source: io::Error },
 
-    #[error("Failed to read block content {hash} for {apath}")]
+    #[error("Failed to read block content {hash} for {apath}: {source}")]
     RestoreFileBlock {
         apath: Apath,
         hash: BlockHash,
         source: Box<Error>,
     },
 
-    #[error("Failed to restore directory {:?}", path)]
+    #[error("Failed to restore directory {path:?}: {source}")]
     RestoreDirectory { path: PathBuf, source: io::Error },
 
-    #[error("Failed to restore ownership of {:?}", path)]
+    #[error("Failed to restore ownership of {path:?}: {source}")]
     RestoreOwnership { path: PathBuf, source: io::Error },
 
-    #[error("Failed to restore permissions on {:?}", path)]
+    #[error("Failed to restore permissions on {path:?}: {source}")]
     RestorePermissions { path: PathBuf, source: io::Error },
 
-    #[error("Failed to restore modification time on {:?}", path)]
+    #[error("Failed to restore modification time on {path:?}: {source}")]
     RestoreModificationTime { path: PathBuf, source: io::Error },
 
     #[error("Unsupported URL scheme {:?}", scheme)]
@@ -174,7 +174,7 @@ pub enum Error {
         source: io::Error,
     },
 
-    #[error("Failed to set owner of {path:?}")]
+    #[error("Failed to set owner of {path:?}: {source}")]
     SetOwner { source: io::Error, path: PathBuf },
 
     #[error(transparent)]
@@ -201,5 +201,35 @@ impl From<jsonio::Error> for Error {
             }, // conflates serialize/deserialize
             jsonio::Error::Transport { source } => Error::Transport { source },
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn block_corrupt_message() {
+        let err = Error::BlockCorrupt {
+            hash: BlockHash::hash_bytes(b"hello"),
+        };
+        assert_eq!(
+            format!("{err}"),
+            "Block file e4cfa39a3d37be31c59609e807970799caa68a19bfaa15135f165085e01d41a65ba1e1b146aeb6bd0092b49eac214c103ccfa3a365954bbbe52f74a2b3620c94 corrupt: does not have the expected hash"
+        );
+    }
+
+    #[test]
+    fn restore_to_nonexistent_directory() {
+        // Hopefully, constructing the error from the `io::ErrorKind` will give consistent
+        // messages across platforms.
+        let err = Error::RestoreFile {
+            path: PathBuf::from("/nonexistent"),
+            source: io::Error::from(io::ErrorKind::NotFound),
+        };
+        assert_eq!(
+            format!("{err}"),
+            "Failed to restore file \"/nonexistent\": entity not found"
+        );
     }
 }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -12,7 +12,7 @@
 
 //! Restore from the archive to the filesystem.
 
-use std::fs::{self, File};
+use std::fs::{create_dir_all, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -147,7 +147,8 @@ fn create_dir(path: &Path) -> io::Result<()> {
             "Simulated failure",
         ))
     });
-    fs::create_dir(path)
+    // Create all the parents in case we're restoring only a nested subtree.
+    create_dir_all(path)
 }
 
 /// Recorded changes to apply to directories after all their contents


### PR DESCRIPTION
* Include the source error in the display form of error messages
