### PR TITLE
Cleaner Transport object

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         features: ["", "s3"]
-        version: [stable, nightly, "1.78"]
+        version: [stable, nightly, "1.79"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "conserve"
 readme = "README.md"
 repository = "https://github.com/sourcefrog/conserve/"
 version = "24.8.0"
-rust-version = "1.78"
+rust-version = "1.79"
 
 [features]
 s3 = [

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -20,14 +20,13 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use itertools::Itertools;
-use jsonio::write_json;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
-use transport::Transport;
 
-use crate::jsonio::read_json;
+use crate::jsonio::{read_json, write_json};
 use crate::monitor::Monitor;
+use crate::transport::Transport;
 use crate::*;
 
 const HEADER_FILENAME: &str = "CONSERVE";

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -24,7 +24,7 @@ use jsonio::write_json;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
-use transport::Transport2;
+use transport::Transport;
 
 use crate::jsonio::read_json;
 use crate::monitor::Monitor;
@@ -40,7 +40,7 @@ pub struct Archive {
     pub(crate) block_dir: Arc<BlockDir>,
 
     /// Transport to the root directory of the archive.
-    transport: Transport2,
+    transport: Transport,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -57,11 +57,11 @@ pub struct DeleteOptions {
 impl Archive {
     /// Make a new archive in a local directory.
     pub fn create_path(path: &Path) -> Result<Archive> {
-        Archive::create(Transport2::local(path))
+        Archive::create(Transport::local(path))
     }
 
     /// Make a new archive in a new directory accessed by a Transport.
-    pub fn create(transport: Transport2) -> Result<Archive> {
+    pub fn create(transport: Transport) -> Result<Archive> {
         transport.create_dir("")?;
         let names = transport.list_dir("")?;
         if !names.files.is_empty() || !names.dirs.is_empty() {
@@ -82,10 +82,10 @@ impl Archive {
     ///
     /// Checks that the header is correct.
     pub fn open_path(path: &Path) -> Result<Archive> {
-        Archive::open(Transport2::local(path))
+        Archive::open(Transport::local(path))
     }
 
-    pub fn open(transport: Transport2) -> Result<Archive> {
+    pub fn open(transport: Transport) -> Result<Archive> {
         let header: ArchiveHeader =
             read_json(&transport, HEADER_FILENAME)?.ok_or(Error::NotAnArchive)?;
         if header.conserve_archive_version != ARCHIVE_VERSION {
@@ -136,7 +136,7 @@ impl Archive {
         Ok(band_ids)
     }
 
-    pub(crate) fn transport(&self) -> &Transport2 {
+    pub(crate) fn transport(&self) -> &Transport {
         &self.transport
     }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -66,7 +66,7 @@ impl Archive {
         if !names.files.is_empty() || !names.dirs.is_empty() {
             return Err(Error::NewArchiveDirectoryNotEmpty);
         }
-        let block_dir = Arc::new(BlockDir::create(transport.sub_transport(BLOCK_DIR))?);
+        let block_dir = Arc::new(BlockDir::create(transport.chdir(BLOCK_DIR))?);
         let header = ArchiveHeader {
             conserve_archive_version: String::from(ARCHIVE_VERSION),
         };
@@ -92,7 +92,7 @@ impl Archive {
                 version: header.conserve_archive_version,
             });
         }
-        let block_dir = Arc::new(BlockDir::open(transport.sub_transport(BLOCK_DIR)));
+        let block_dir = Arc::new(BlockDir::open(transport.chdir(BLOCK_DIR)));
         debug!(?header, "Opened archive");
         Ok(Archive {
             block_dir,

--- a/src/band.rs
+++ b/src/band.rs
@@ -24,11 +24,11 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use crate::transport::Transport;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::{debug, warn};
-use transport::Transport;
 
 use crate::jsonio::{read_json, write_json};
 use crate::misc::remove_item;

--- a/src/band.rs
+++ b/src/band.rs
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::{debug, warn};
-use transport::Transport2;
+use transport::Transport;
 
 use crate::jsonio::{read_json, write_json};
 use crate::misc::remove_item;
@@ -76,7 +76,7 @@ pub struct Band {
     band_id: BandId,
 
     /// Transport pointing to the archive directory.
-    transport: Transport2,
+    transport: Transport,
 
     /// Deserialized band head info.
     head: Head,

--- a/src/band.rs
+++ b/src/band.rs
@@ -144,7 +144,7 @@ impl Band {
         let band_id = archive
             .last_band_id()?
             .map_or_else(BandId::zero, |b| b.next_sibling());
-        let transport = archive.transport().sub_transport(&band_id.to_string());
+        let transport = archive.transport().chdir(&band_id.to_string());
         transport.create_dir("")?;
         transport.create_dir(INDEX_DIR)?;
         let band_format_version = if format_flags.is_empty() {
@@ -180,7 +180,7 @@ impl Band {
 
     /// Open the band with the given id.
     pub fn open(archive: &Archive, band_id: BandId) -> Result<Band> {
-        let transport = archive.transport().sub_transport(&band_id.to_string());
+        let transport = archive.transport().chdir(&band_id.to_string());
         let head: Head =
             read_json(&transport, BAND_HEAD_FILENAME)?.ok_or(Error::BandHeadMissing { band_id })?;
         if let Some(version) = &head.band_format_version {
@@ -251,12 +251,12 @@ impl Band {
     }
 
     pub fn index_builder(&self) -> IndexWriter {
-        IndexWriter::new(self.transport.sub_transport(INDEX_DIR))
+        IndexWriter::new(self.transport.chdir(INDEX_DIR))
     }
 
     /// Get read-only access to the index of this band.
     pub fn index(&self) -> IndexRead {
-        IndexRead::open(self.transport.sub_transport(INDEX_DIR))
+        IndexRead::open(self.transport.chdir(INDEX_DIR))
     }
 
     /// Return info about the state of this band.

--- a/src/band.rs
+++ b/src/band.rs
@@ -28,6 +28,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::{debug, warn};
+use transport::Transport2;
 
 use crate::jsonio::{read_json, write_json};
 use crate::misc::remove_item;
@@ -75,7 +76,7 @@ pub struct Band {
     band_id: BandId,
 
     /// Transport pointing to the archive directory.
-    transport: Arc<dyn Transport>,
+    transport: Transport2,
 
     /// Deserialized band head info.
     head: Head,

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -28,9 +28,9 @@ use time::UtcOffset;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn, Level};
 
+use crate::transport::Transport;
 use conserve::termui::{enable_tracing, TermUiMonitor, TraceTimeStyle};
 use conserve::*;
-use transport::Transport;
 
 /// Local timezone offset, calculated once at startup, to avoid issues about
 /// looking at the environment once multiple threads are running.

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -30,6 +30,7 @@ use tracing::{debug, error, info, trace, warn, Level};
 
 use conserve::termui::{enable_tracing, TermUiMonitor, TraceTimeStyle};
 use conserve::*;
+use transport::Transport2;
 
 /// Local timezone offset, calculated once at startup, to avoid issues about
 /// looking at the environment once multiple threads are running.
@@ -327,7 +328,7 @@ impl Command {
                     ..Default::default()
                 };
                 let stats = backup(
-                    &Archive::open(open_transport(archive)?)?,
+                    &Archive::open(Transport2::new(archive)?)?,
                     source,
                     &options,
                     monitor,
@@ -338,7 +339,7 @@ impl Command {
             }
             Command::Debug(Debug::Blocks { archive }) => {
                 let mut bw = BufWriter::new(stdout);
-                for hash in Archive::open(open_transport(archive)?)?
+                for hash in Archive::open(Transport2::new(archive)?)?
                     .block_dir()
                     .blocks(monitor)?
                     .collect::<Vec<BlockHash>>()
@@ -353,7 +354,7 @@ impl Command {
             }
             Command::Debug(Debug::Referenced { archive }) => {
                 let mut bw = BufWriter::new(stdout);
-                let archive = Archive::open(open_transport(archive)?)?;
+                let archive = Archive::open(Transport2::new(archive)?)?;
                 for hash in archive.referenced_blocks(&archive.list_band_ids()?, monitor)? {
                     writeln!(bw, "{hash}")?;
                 }
@@ -361,7 +362,7 @@ impl Command {
             Command::Debug(Debug::Unreferenced { archive }) => {
                 print!(
                     "{}",
-                    Archive::open(open_transport(archive)?)?
+                    Archive::open(Transport2::new(archive)?)?
                         .unreferenced_blocks(monitor)?
                         .map(|hash| format!("{}\n", hash))
                         .collect::<Vec<String>>()
@@ -375,7 +376,7 @@ impl Command {
                 break_lock,
                 no_stats,
             } => {
-                let stats = Archive::open(open_transport(archive)?)?.delete_bands(
+                let stats = Archive::open(Transport2::new(archive)?)?.delete_bands(
                     backup,
                     &DeleteOptions {
                         dry_run: *dry_run,
@@ -418,7 +419,7 @@ impl Command {
                 break_lock,
                 no_stats,
             } => {
-                let archive = Archive::open(open_transport(archive)?)?;
+                let archive = Archive::open(Transport2::new(archive)?)?;
                 let stats = archive.delete_bands(
                     &[],
                     &DeleteOptions {
@@ -432,7 +433,7 @@ impl Command {
                 }
             }
             Command::Init { archive } => {
-                Archive::create(open_transport(archive)?)?;
+                Archive::create(Transport2::new(archive)?)?;
                 debug!("Created new archive in {archive:?}");
             }
             Command::Ls {
@@ -481,7 +482,7 @@ impl Command {
                 no_stats,
             } => {
                 let band_selection = band_selection_policy_from_opt(backup);
-                let archive = Archive::open(open_transport(archive)?)?;
+                let archive = Archive::open(Transport2::new(archive)?)?;
                 let _ = no_stats; // accepted but ignored; we never currently print stats
                 let options = RestoreOptions {
                     exclude: Exclude::from_patterns_and_files(exclude, exclude_from)?,
@@ -524,7 +525,7 @@ impl Command {
                 let options = ValidateOptions {
                     skip_block_hashes: *quick,
                 };
-                Archive::open(open_transport(archive)?)?.validate(&options, monitor.clone())?;
+                Archive::open(Transport2::new(archive)?)?.validate(&options, monitor.clone())?;
                 if monitor.error_count() != 0 {
                     warn!("Archive has some problems.");
                 } else {
@@ -543,7 +544,7 @@ impl Command {
                 } else {
                     Some(*LOCAL_OFFSET.read().unwrap())
                 };
-                let archive = Archive::open(open_transport(archive)?)?;
+                let archive = Archive::open(Transport2::new(archive)?)?;
                 let options = ShowVersionsOptions {
                     newest_first: *newest,
                     tree_size: *sizes,
@@ -559,7 +560,7 @@ impl Command {
 }
 
 fn stored_tree_from_opt(archive_location: &str, backup: &Option<BandId>) -> Result<StoredTree> {
-    let archive = Archive::open(open_transport(archive_location)?)?;
+    let archive = Archive::open(Transport2::new(archive_location)?)?;
     let policy = band_selection_policy_from_opt(backup);
     archive.open_stored_tree(policy)
 }

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -30,7 +30,7 @@ use tracing::{debug, error, info, trace, warn, Level};
 
 use conserve::termui::{enable_tracing, TermUiMonitor, TraceTimeStyle};
 use conserve::*;
-use transport::Transport2;
+use transport::Transport;
 
 /// Local timezone offset, calculated once at startup, to avoid issues about
 /// looking at the environment once multiple threads are running.
@@ -328,7 +328,7 @@ impl Command {
                     ..Default::default()
                 };
                 let stats = backup(
-                    &Archive::open(Transport2::new(archive)?)?,
+                    &Archive::open(Transport::new(archive)?)?,
                     source,
                     &options,
                     monitor,
@@ -339,7 +339,7 @@ impl Command {
             }
             Command::Debug(Debug::Blocks { archive }) => {
                 let mut bw = BufWriter::new(stdout);
-                for hash in Archive::open(Transport2::new(archive)?)?
+                for hash in Archive::open(Transport::new(archive)?)?
                     .block_dir()
                     .blocks(monitor)?
                     .collect::<Vec<BlockHash>>()
@@ -354,7 +354,7 @@ impl Command {
             }
             Command::Debug(Debug::Referenced { archive }) => {
                 let mut bw = BufWriter::new(stdout);
-                let archive = Archive::open(Transport2::new(archive)?)?;
+                let archive = Archive::open(Transport::new(archive)?)?;
                 for hash in archive.referenced_blocks(&archive.list_band_ids()?, monitor)? {
                     writeln!(bw, "{hash}")?;
                 }
@@ -362,7 +362,7 @@ impl Command {
             Command::Debug(Debug::Unreferenced { archive }) => {
                 print!(
                     "{}",
-                    Archive::open(Transport2::new(archive)?)?
+                    Archive::open(Transport::new(archive)?)?
                         .unreferenced_blocks(monitor)?
                         .map(|hash| format!("{}\n", hash))
                         .collect::<Vec<String>>()
@@ -376,7 +376,7 @@ impl Command {
                 break_lock,
                 no_stats,
             } => {
-                let stats = Archive::open(Transport2::new(archive)?)?.delete_bands(
+                let stats = Archive::open(Transport::new(archive)?)?.delete_bands(
                     backup,
                     &DeleteOptions {
                         dry_run: *dry_run,
@@ -419,7 +419,7 @@ impl Command {
                 break_lock,
                 no_stats,
             } => {
-                let archive = Archive::open(Transport2::new(archive)?)?;
+                let archive = Archive::open(Transport::new(archive)?)?;
                 let stats = archive.delete_bands(
                     &[],
                     &DeleteOptions {
@@ -433,7 +433,7 @@ impl Command {
                 }
             }
             Command::Init { archive } => {
-                Archive::create(Transport2::new(archive)?)?;
+                Archive::create(Transport::new(archive)?)?;
                 debug!("Created new archive in {archive:?}");
             }
             Command::Ls {
@@ -482,7 +482,7 @@ impl Command {
                 no_stats,
             } => {
                 let band_selection = band_selection_policy_from_opt(backup);
-                let archive = Archive::open(Transport2::new(archive)?)?;
+                let archive = Archive::open(Transport::new(archive)?)?;
                 let _ = no_stats; // accepted but ignored; we never currently print stats
                 let options = RestoreOptions {
                     exclude: Exclude::from_patterns_and_files(exclude, exclude_from)?,
@@ -525,7 +525,7 @@ impl Command {
                 let options = ValidateOptions {
                     skip_block_hashes: *quick,
                 };
-                Archive::open(Transport2::new(archive)?)?.validate(&options, monitor.clone())?;
+                Archive::open(Transport::new(archive)?)?.validate(&options, monitor.clone())?;
                 if monitor.error_count() != 0 {
                     warn!("Archive has some problems.");
                 } else {
@@ -544,7 +544,7 @@ impl Command {
                 } else {
                     Some(*LOCAL_OFFSET.read().unwrap())
                 };
-                let archive = Archive::open(Transport2::new(archive)?)?;
+                let archive = Archive::open(Transport::new(archive)?)?;
                 let options = ShowVersionsOptions {
                     newest_first: *newest,
                     tree_size: *sizes,
@@ -560,7 +560,7 @@ impl Command {
 }
 
 fn stored_tree_from_opt(archive_location: &str, backup: &Option<BandId>) -> Result<StoredTree> {
-    let archive = Archive::open(Transport2::new(archive_location)?)?;
+    let archive = Archive::open(Transport::new(archive_location)?)?;
     let policy = band_selection_policy_from_opt(backup);
     archive.open_stored_tree(policy)
 }

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -36,7 +36,7 @@ use tracing::{instrument, trace};
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::counters::Counter;
 use crate::monitor::Monitor;
-use crate::transport::{Transport2,ListDir};
+use crate::transport::{ListDir, Transport2};
 use crate::*;
 
 // const BLOCKDIR_FILE_NAME_LEN: usize = crate::BLAKE_HASH_SIZE_BYTES * 2;

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -343,7 +343,6 @@ mod test {
     use tempfile::TempDir;
 
     use crate::monitor::test::TestMonitor;
-    use crate::transport::open_local_transport;
 
     use super::*;
 
@@ -353,7 +352,7 @@ mod test {
         // file with 0 bytes. It's not valid compressed data. We just treat
         // the block as not present at all.
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(open_local_transport(tempdir.path()).unwrap());
+        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
         let mut stats = BackupStats::default();
         let monitor = TestMonitor::arc();
         let hash = blockdir
@@ -367,7 +366,7 @@ mod test {
         assert_eq!(monitor.get_counter(Counter::BlockExistenceCacheHit), 1); // Since we just wrote it, we know it's there.
 
         // Open again to get a fresh cache
-        let blockdir = BlockDir::open(open_local_transport(tempdir.path()).unwrap());
+        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
         let monitor = TestMonitor::arc();
         OpenOptions::new()
             .write(true)
@@ -383,7 +382,7 @@ mod test {
     #[test]
     fn temp_files_are_not_returned_as_blocks() {
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(open_local_transport(tempdir.path()).unwrap());
+        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
         let monitor = TestMonitor::arc();
         let subdir = tempdir.path().join(subdir_relpath("123"));
         create_dir(&subdir).unwrap();
@@ -402,7 +401,7 @@ mod test {
     #[test]
     fn cache_hit() {
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(open_local_transport(tempdir.path()).unwrap());
+        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
         let mut stats = BackupStats::default();
         let content = Bytes::from("stuff");
         let hash = blockdir
@@ -432,7 +431,7 @@ mod test {
     #[test]
     fn existence_cache_hit() {
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(open_local_transport(tempdir.path()).unwrap());
+        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
         let mut stats = BackupStats::default();
         let content = Bytes::from("stuff");
         let monitor = TestMonitor::arc();
@@ -442,7 +441,7 @@ mod test {
 
         // reopen
         let monitor = TestMonitor::arc();
-        let blockdir = BlockDir::open(open_local_transport(tempdir.path()).unwrap());
+        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
         assert!(blockdir.contains(&hash, monitor.clone()).unwrap());
         assert_eq!(blockdir.stats.cache_hit.load(Relaxed), 0);
         assert_eq!(monitor.get_counter(Counter::BlockExistenceCacheHit), 0);

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -36,7 +36,7 @@ use tracing::{instrument, trace};
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::counters::Counter;
 use crate::monitor::Monitor;
-use crate::transport::{ListDir, Transport2};
+use crate::transport::{ListDir, Transport};
 use crate::*;
 
 // const BLOCKDIR_FILE_NAME_LEN: usize = crate::BLAKE_HASH_SIZE_BYTES * 2;
@@ -65,7 +65,7 @@ pub struct Address {
 /// A readable, writable directory within a band holding data blocks.
 #[derive(Debug)]
 pub struct BlockDir {
-    transport: Transport2,
+    transport: Transport,
     pub stats: BlockDirStats,
     // TODO: There are fancier caches and they might help, but this one works, and Stretto did not work for me.
     cache: RwLock<LruCache<BlockHash, Bytes>>,
@@ -85,7 +85,7 @@ pub fn block_relpath(hash: &BlockHash) -> String {
 }
 
 impl BlockDir {
-    pub fn open(transport: Transport2) -> BlockDir {
+    pub fn open(transport: Transport) -> BlockDir {
         /// Cache this many blocks in memory.
         // TODO: Change to a cache that tracks the size of stored blocks?
         // As a safe conservative value, 100 blocks of 20MB each would be 2GB.
@@ -102,7 +102,7 @@ impl BlockDir {
         }
     }
 
-    pub fn create(transport: Transport2) -> Result<BlockDir> {
+    pub fn create(transport: Transport) -> Result<BlockDir> {
         transport.create_dir("")?;
         Ok(BlockDir::open(transport))
     }
@@ -352,7 +352,7 @@ mod test {
         // file with 0 bytes. It's not valid compressed data. We just treat
         // the block as not present at all.
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
+        let blockdir = BlockDir::open(Transport::local(tempdir.path()));
         let mut stats = BackupStats::default();
         let monitor = TestMonitor::arc();
         let hash = blockdir
@@ -366,7 +366,7 @@ mod test {
         assert_eq!(monitor.get_counter(Counter::BlockExistenceCacheHit), 1); // Since we just wrote it, we know it's there.
 
         // Open again to get a fresh cache
-        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
+        let blockdir = BlockDir::open(Transport::local(tempdir.path()));
         let monitor = TestMonitor::arc();
         OpenOptions::new()
             .write(true)
@@ -382,7 +382,7 @@ mod test {
     #[test]
     fn temp_files_are_not_returned_as_blocks() {
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
+        let blockdir = BlockDir::open(Transport::local(tempdir.path()));
         let monitor = TestMonitor::arc();
         let subdir = tempdir.path().join(subdir_relpath("123"));
         create_dir(&subdir).unwrap();
@@ -401,7 +401,7 @@ mod test {
     #[test]
     fn cache_hit() {
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
+        let blockdir = BlockDir::open(Transport::local(tempdir.path()));
         let mut stats = BackupStats::default();
         let content = Bytes::from("stuff");
         let hash = blockdir
@@ -431,7 +431,7 @@ mod test {
     #[test]
     fn existence_cache_hit() {
         let tempdir = TempDir::new().unwrap();
-        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
+        let blockdir = BlockDir::open(Transport::local(tempdir.path()));
         let mut stats = BackupStats::default();
         let content = Bytes::from("stuff");
         let monitor = TestMonitor::arc();
@@ -441,7 +441,7 @@ mod test {
 
         // reopen
         let monitor = TestMonitor::arc();
-        let blockdir = BlockDir::open(Transport2::local(tempdir.path()));
+        let blockdir = BlockDir::open(Transport::local(tempdir.path()));
         assert!(blockdir.contains(&hash, monitor.clone()).unwrap());
         assert_eq!(blockdir.stats.cache_hit.load(Relaxed), 0);
         assert_eq!(monitor.get_counter(Counter::BlockExistenceCacheHit), 0);

--- a/src/blockdir.rs
+++ b/src/blockdir.rs
@@ -36,7 +36,7 @@ use tracing::{instrument, trace};
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::counters::Counter;
 use crate::monitor::Monitor;
-use crate::transport::ListDir;
+use crate::transport::{Transport2,ListDir};
 use crate::*;
 
 // const BLOCKDIR_FILE_NAME_LEN: usize = crate::BLAKE_HASH_SIZE_BYTES * 2;
@@ -65,7 +65,7 @@ pub struct Address {
 /// A readable, writable directory within a band holding data blocks.
 #[derive(Debug)]
 pub struct BlockDir {
-    transport: Arc<dyn Transport>,
+    transport: Transport2,
     pub stats: BlockDirStats,
     // TODO: There are fancier caches and they might help, but this one works, and Stretto did not work for me.
     cache: RwLock<LruCache<BlockHash, Bytes>>,
@@ -85,7 +85,7 @@ pub fn block_relpath(hash: &BlockHash) -> String {
 }
 
 impl BlockDir {
-    pub fn open(transport: Arc<dyn Transport>) -> BlockDir {
+    pub fn open(transport: Transport2) -> BlockDir {
         /// Cache this many blocks in memory.
         // TODO: Change to a cache that tracks the size of stored blocks?
         // As a safe conservative value, 100 blocks of 20MB each would be 2GB.
@@ -102,7 +102,7 @@ impl BlockDir {
         }
     }
 
-    pub fn create(transport: Arc<dyn Transport>) -> Result<BlockDir> {
+    pub fn create(transport: Transport2) -> Result<BlockDir> {
         transport.create_dir("")?;
         Ok(BlockDir::open(transport))
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -19,10 +19,10 @@ use std::path::Path;
 use std::sync::Arc;
 use std::vec;
 
+use crate::transport::Transport;
 use itertools::Itertools;
 use time::OffsetDateTime;
 use tracing::{debug, debug_span, error};
-use transport::Transport;
 
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::counters::Counter;

--- a/src/index.rs
+++ b/src/index.rs
@@ -22,7 +22,7 @@ use std::vec;
 use itertools::Itertools;
 use time::OffsetDateTime;
 use tracing::{debug, debug_span, error};
-use transport::Transport2;
+use transport::Transport;
 
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::counters::Counter;
@@ -177,7 +177,7 @@ impl IndexEntry {
 /// hunks preserve apath order.
 pub struct IndexWriter {
     /// The `i` directory within the band where all files for this index are written.
-    transport: Transport2,
+    transport: Transport,
 
     /// Currently queued entries to be written out, in arbitrary order.
     entries: Vec<IndexEntry>,
@@ -199,7 +199,7 @@ pub struct IndexWriter {
 /// Accumulate and write out index entries into files in an index directory.
 impl IndexWriter {
     /// Make a new builder that will write files into the given directory.
-    pub fn new(transport: Transport2) -> IndexWriter {
+    pub fn new(transport: Transport) -> IndexWriter {
         IndexWriter {
             transport,
             entries: Vec::new(),
@@ -279,17 +279,17 @@ fn hunk_relpath(hunk_number: u32) -> String {
 #[derive(Debug, Clone)]
 pub struct IndexRead {
     /// Transport pointing to this index directory.
-    transport: Transport2,
+    transport: Transport,
 }
 
 impl IndexRead {
     #[allow(unused)]
     // TODO: Deprecate, use Transport?
     pub(crate) fn open_path(path: &Path) -> IndexRead {
-        IndexRead::open(Transport2::local(path))
+        IndexRead::open(Transport::local(path))
     }
 
-    pub(crate) fn open(transport: Transport2) -> IndexRead {
+    pub(crate) fn open(transport: Transport) -> IndexRead {
         IndexRead { transport }
     }
 
@@ -336,7 +336,7 @@ impl IndexRead {
 pub struct IndexHunkIter {
     hunks: std::vec::IntoIter<u32>,
     /// The `i` directory within the band where all files for this index are written.
-    transport: Transport2,
+    transport: Transport,
     decompressor: Decompressor,
     pub stats: IndexReadStats,
     /// If set, yield only entries ordered after this apath.
@@ -525,7 +525,7 @@ mod tests {
 
     fn setup() -> (TempDir, IndexWriter) {
         let testdir = TempDir::new().unwrap();
-        let ib = IndexWriter::new(Transport2::local(testdir.path()));
+        let ib = IndexWriter::new(Transport::local(testdir.path()));
         (testdir, ib)
     }
 

--- a/src/jsonio.rs
+++ b/src/jsonio.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 
 use serde::de::DeserializeOwned;
 
-use crate::transport::{self, Transport2};
+use crate::transport::{self, Transport};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -44,7 +44,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Write uncompressed json to a file on a Transport.
-pub(crate) fn write_json<T>(transport: &Transport2, relpath: &str, obj: &T) -> Result<()>
+pub(crate) fn write_json<T>(transport: &Transport, relpath: &str, obj: &T) -> Result<()>
 where
     T: serde::Serialize,
 {
@@ -61,7 +61,7 @@ where
 /// Read and deserialize uncompressed json from a file on a Transport.
 ///
 /// Returns None if the file does not exist.
-pub(crate) fn read_json<T>(transport: &Transport2, path: &str) -> Result<Option<T>>
+pub(crate) fn read_json<T>(transport: &Transport, path: &str) -> Result<Option<T>>
 where
     T: DeserializeOwned,
 {
@@ -101,7 +101,7 @@ mod tests {
         };
         let filename = "test.json";
 
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
         super::write_json(&transport, filename, &entry).unwrap();
 
         let json_child = temp.child("test.json");
@@ -117,7 +117,7 @@ mod tests {
             .write_str(r#"{"id": 42, "weather": "cold"}"#)
             .unwrap();
 
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
         let content: TestContents = read_json(&transport, "test.json")
             .expect("no error")
             .expect("file exists");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,6 @@ pub use crate::restore::{restore, RestoreOptions};
 pub use crate::show::{show_versions, ShowVersionsOptions};
 pub use crate::stats::DeleteStats;
 pub use crate::stored_tree::StoredTree;
-pub use crate::transport::Transport;
 pub use crate::tree::{ReadTree, TreeSize};
 pub use crate::unix_mode::UnixMode;
 pub use crate::validate::ValidateOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub use crate::restore::{restore, RestoreOptions};
 pub use crate::show::{show_versions, ShowVersionsOptions};
 pub use crate::stats::DeleteStats;
 pub use crate::stored_tree::StoredTree;
-pub use crate::transport::{open_transport, Transport};
+pub use crate::transport::Transport;
 pub use crate::tree::{ReadTree, TreeSize};
 pub use crate::unix_mode::UnixMode;
 pub use crate::validate::ValidateOptions;

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 use crate::monitor::test::TestMonitor;
-use crate::transport::Transport2;
+use crate::transport::Transport;
 use crate::*;
 
 /// A temporary archive, deleted when it goes out of scope.
@@ -72,7 +72,7 @@ impl ScratchArchive {
         backup(&self.archive, srcdir.path(), options, TestMonitor::arc()).unwrap();
     }
 
-    pub fn transport(&self) -> &Transport2 {
+    pub fn transport(&self) -> &Transport {
         self.archive.transport()
     }
 }

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 use crate::monitor::test::TestMonitor;
+use crate::transport::Transport2;
 use crate::*;
 
 /// A temporary archive, deleted when it goes out of scope.
@@ -71,7 +72,7 @@ impl ScratchArchive {
         backup(&self.archive, srcdir.path(), options, TestMonitor::arc()).unwrap();
     }
 
-    pub fn transport(&self) -> &dyn Transport {
+    pub fn transport(&self) -> &Transport2 {
         self.archive.transport()
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -110,7 +110,7 @@ impl Transport {
     }
 
     /// Make a new transport addressing a subdirectory.
-    pub fn sub_transport(&self, relpath: &str) -> Self {
+    pub fn chdir(&self, relpath: &str) -> Self {
         Transport {
             protocol: self.protocol.chdir(relpath),
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -14,7 +14,7 @@
 //!
 //! Transport operations return std::io::Result to reflect their narrower focus.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{error, fmt, io, result};
 
@@ -28,39 +28,20 @@ pub mod local;
 #[cfg(feature = "sftp")]
 pub mod sftp;
 
-use local::LocalTransport;
-
 #[cfg(feature = "s3")]
 pub mod s3;
 
 /// Open a `Transport` to access a local directory.
 ///
 /// `s` may be a local path or a URL.
-pub fn open_transport(s: &str) -> crate::Result<Arc<dyn Transport>> {
-    if let Ok(url) = Url::parse(s) {
-        match url.scheme() {
-            "file" => Ok(Arc::new(LocalTransport::new(
-                &url.to_file_path().expect("extract URL file path"),
-            ))),
-            #[cfg(feature = "s3")]
-            "s3" => Ok(s3::S3Transport::new(&url)?),
-            d if d.len() == 1 => {
-                // Probably a Windows path with drive letter, like "c:/thing", not actually a URL.
-                Ok(Arc::new(LocalTransport::new(Path::new(s))))
-            }
-            #[cfg(feature = "sftp")]
-            "sftp" => Ok(Arc::new(sftp::SftpTransport::new(&url)?)),
-            other => Err(crate::Error::UrlScheme {
-                scheme: other.to_owned(),
-            }),
-        }
-    } else {
-        Ok(Arc::new(LocalTransport::new(Path::new(s))))
-    }
+// TODO: Deprecate for Transport::new
+pub fn open_transport(s: &str) -> crate::Result<Transport2> {
+    Ok(Transport2::new(s)?)
 }
 
-pub fn open_local_transport(path: &Path) -> crate::Result<Arc<dyn Transport>> {
-    Ok(Arc::new(LocalTransport::new(path)))
+// TODO: Deprecate and use Transport2::local
+pub fn open_local_transport(path: &Path) -> Result<Transport2> {
+    Ok(Transport2::local(path))
 }
 
 /// Abstracted filesystem IO to access an archive.
@@ -71,25 +52,160 @@ pub fn open_local_transport(path: &Path) -> crate::Result<Arc<dyn Transport>> {
 /// A transport has a root location, which will typically be the top directory of the Archive.
 /// Below that point everything is accessed with a relative path, expressed as a PathBuf.
 ///
-/// All Transports must be `Send + Sync`, so they can be passed across or shared across threads.
+/// Transport objects can be cheaply cloned.
 ///
 /// Files in Conserve archives have bounded size and fit in memory so this does not need to
 /// support streaming or partial reads and writes.
-pub trait Transport: Send + Sync + std::fmt::Debug {
-    /// List a directory, separating out file and subdirectory names.
-    ///
-    /// Names are in the arbitrary order that they're returned from the transport.
-    ///
-    /// Any error during iteration causes overall failure.
-    fn list_dir(&self, relpath: &str) -> Result<ListDir>;
+#[derive(Clone)]
+pub struct Transport2 {
+    protocol: Arc<dyn Protocol+ 'static>,
+}
+
+impl Transport2 {
+    /// Open a new local transport addressing a filesystem directory.
+    pub fn local(path: &Path) -> Self {
+        Transport2 {
+            protocol: Arc::new(local::Protocol::new(path)),
+        }
+    }
+
+    /// Open a new transport from a string that might be a URL or local path.
+    pub fn new(s: &str) -> Result<Self> {
+        if let Ok(url) = Url::parse(s) {
+            Transport2::from_url(&url)
+        } else {
+            Ok(Transport2::local(Path::new(s)))
+        }
+    }
+
+    pub fn from_url(url: &Url) -> Result<Self> {
+        let protocol: Arc<dyn Protocol> = match url.scheme() {
+            "file" => Arc::new(local::Protocol::new(
+                &url.to_file_path().expect("extract URL file path"),
+            )),
+            d if d.len() == 1 => {
+                // Probably a Windows path with drive letter, like "c:/thing", not actually a URL.
+                Arc::new(local::Protocol::new(Path::new(url.as_str())))
+            }
+
+            #[cfg(feature = "s3")]
+            "s3" => Arc::new(s3::Protocol::new(&url)?),
+
+            #[cfg(feature = "sftp")]
+            "sftp" => Arc::new(sftp::Protocol::new(&url)?),
+
+            _other => {
+                return Err(Error {
+                    kind: ErrorKind::UrlScheme,
+                    path: Some(url.as_str().to_owned()),
+                    source: None,
+                })
+            }
+        };
+        Ok(Transport2 {
+            protocol,
+        })
+    }
 
     /// Get one complete file into a caller-provided buffer.
     ///
     /// Files in the archive are of bounded size, so it's OK to always read them entirely into
     /// memory, and this is simple to support on all implementations.
-    fn read_file(&self, path: &str) -> Result<Bytes>;
+    pub fn read_file(&self, path: &str) -> Result<Bytes> {
+        self.protocol.read_file(path)
+    }
+
+    /// List a directory, separating out file and subdirectory names.
+    ///
+    /// Names are in the arbitrary order that they're returned from the transport.
+    ///
+    /// Any error during iteration causes overall failure.
+    pub fn list_dir(&self, relpath: &str) -> Result<ListDir> {
+        self.protocol.list_dir(relpath)
+    }
+
+    /// Make a new transport addressing a subdirectory.
+    pub fn sub_transport(&self, relpath: &str) -> Self {
+        Transport2 {
+            protocol: self.protocol.chdir(relpath),
+        }
+    }
+
+    pub fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()> {
+        self.protocol.write_file(relpath, content)
+    }
+
+    pub fn create_dir(&self, relpath: &str) -> Result<()> {
+        self.protocol.create_dir(relpath)
+    }
+
+    pub fn metadata(&self, relpath: &str) -> Result<Metadata> {
+        self.protocol.metadata(relpath)
+    }
+
+    /// Delete a file.
+    pub fn remove_file(&self, relpath: &str) -> Result<()> {
+        self.protocol.remove_file(relpath)
+    }
+
+    /// Delete a directory and all its contents.
+    pub fn remove_dir_all(&self, relpath: &str) -> Result<()> {
+        self.protocol.remove_dir_all(relpath)
+    }
 
     /// Check if a regular file exists.
+    pub fn is_file(&self, path: &str) -> Result<bool> {
+        match self.metadata(path) {
+            Ok(metadata) => Ok(metadata.kind == Kind::File),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn url(&self) -> &Url {
+        self.protocol.url()
+    }
+
+    #[allow(unused)]
+    fn local_path(&self) -> Option<PathBuf> {
+        self.protocol.local_path()
+    }
+}
+
+impl fmt::Debug for Transport2 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Transport2({})", self.url())
+    }
+}
+
+trait Protocol: Send + Sync {
+    fn read_file(&self, path: &str) -> Result<Bytes>;
+    fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()>;
+    fn list_dir(&self, relpath: &str) -> Result<ListDir>;
+    fn create_dir(&self, relpath: &str) -> Result<()>;
+    fn metadata(&self, relpath: &str) -> Result<Metadata>;
+
+    /// Delete a file.
+    fn remove_file(&self, relpath: &str) -> Result<()>;
+
+    /// Delete a directory and all its contents.
+    fn remove_dir_all(&self, relpath: &str) -> Result<()>;
+
+    /// Make a new transport addressing a subdirectory.
+    fn chdir(&self, relpath: &str) -> Arc<dyn Protocol>;
+
+    fn url(&self) -> &Url;
+
+    fn local_path(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+pub trait Transport: Send + Sync + std::fmt::Debug {
+    fn list_dir(&self, relpath: &str) -> Result<ListDir>;
+
+    fn read_file(&self, path: &str) -> Result<Bytes>;
+
     fn is_file(&self, path: &str) -> Result<bool> {
         match self.metadata(path) {
             Ok(metadata) => Ok(metadata.kind == Kind::File),
@@ -178,6 +294,9 @@ pub enum ErrorKind {
     #[display(fmt = "Permission denied")]
     PermissionDenied,
 
+    #[display(fmt = "Unsupported URL scheme")]
+    UrlScheme,
+
     #[display(fmt = "Other transport error")]
     Other,
 }
@@ -237,3 +356,16 @@ impl error::Error for Error {
 }
 
 type Result<T> = result::Result<T, Error>;
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::Transport2;
+
+    #[test]
+    fn get_path_from_local_transport() {
+        let transport = Transport2::local(Path::new("/tmp"));
+        assert_eq!(transport.local_path().as_deref(), Some(Path::new("/tmp")));
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -58,7 +58,7 @@ pub fn open_local_transport(path: &Path) -> Result<Transport2> {
 /// support streaming or partial reads and writes.
 #[derive(Clone)]
 pub struct Transport2 {
-    protocol: Arc<dyn Protocol+ 'static>,
+    protocol: Arc<dyn Protocol + 'static>,
 }
 
 impl Transport2 {
@@ -102,9 +102,7 @@ impl Transport2 {
                 })
             }
         };
-        Ok(Transport2 {
-            protocol,
-        })
+        Ok(Transport2 { protocol })
     }
 
     /// Get one complete file into a caller-provided buffer.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -31,19 +31,6 @@ pub mod sftp;
 #[cfg(feature = "s3")]
 pub mod s3;
 
-/// Open a `Transport` to access a local directory.
-///
-/// `s` may be a local path or a URL.
-// TODO: Deprecate for Transport::new
-pub fn open_transport(s: &str) -> crate::Result<Transport2> {
-    Ok(Transport2::new(s)?)
-}
-
-// TODO: Deprecate and use Transport2::local
-pub fn open_local_transport(path: &Path) -> Result<Transport2> {
-    Ok(Transport2::local(path))
-}
-
 /// Abstracted filesystem IO to access an archive.
 ///
 /// This supports operations that are common across local filesystems, SFTP, and cloud storage, and
@@ -89,7 +76,7 @@ impl Transport2 {
             }
 
             #[cfg(feature = "s3")]
-            "s3" => Arc::new(s3::Protocol::new(&url)?),
+            "s3" => Arc::new(s3::Protocol::new(&url)),
 
             #[cfg(feature = "sftp")]
             "sftp" => Arc::new(sftp::Protocol::new(&url)?),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -76,10 +76,10 @@ impl Transport {
             }
 
             #[cfg(feature = "s3")]
-            "s3" => Arc::new(s3::Protocol::new(&url)?),
+            "s3" => Arc::new(s3::Protocol::new(url)?),
 
             #[cfg(feature = "sftp")]
-            "sftp" => Arc::new(sftp::Protocol::new(&url)?),
+            "sftp" => Arc::new(sftp::Protocol::new(url)?),
 
             _other => {
                 return Err(Error {

--- a/src/transport/local.rs
+++ b/src/transport/local.rs
@@ -322,7 +322,7 @@ mod test {
         transport.create_dir("aaa").unwrap();
         transport.create_dir("aaa/bbb").unwrap();
 
-        let sub_transport = transport.sub_transport("aaa");
+        let sub_transport = transport.chdir("aaa");
         let sub_list = sub_transport.list_dir("").unwrap();
 
         assert_eq!(sub_list.dirs, ["bbb"]);

--- a/src/transport/local.rs
+++ b/src/transport/local.rs
@@ -13,10 +13,10 @@
 //! Access to an archive on the local filesystem.
 
 use std::fs::{create_dir, File};
-use std::{io, path};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{io, path};
 
 use bytes::Bytes;
 use tracing::{instrument, trace, warn};
@@ -168,7 +168,8 @@ impl Protocol {
     pub(super) fn new(path: &Path) -> Self {
         Protocol {
             path: path.to_owned(),
-            url: Url::from_directory_path(path::absolute(path).expect("make path absolute")).expect("convert path to URL"),
+            url: Url::from_directory_path(path::absolute(path).expect("make path absolute"))
+                .expect("convert path to URL"),
         }
     }
 }

--- a/src/transport/local.rs
+++ b/src/transport/local.rs
@@ -167,7 +167,7 @@ mod test {
 
     use super::*;
     use crate::kind::Kind;
-    use crate::transport::{self, Transport2};
+    use crate::transport::{self, Transport};
 
     #[test]
     fn read_file() {
@@ -177,7 +177,7 @@ mod test {
 
         temp.child(filename).write_str(content).unwrap();
 
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
         let buf = transport.read_file(filename).unwrap();
         assert_eq!(buf, content.as_bytes());
 
@@ -187,7 +187,7 @@ mod test {
     #[test]
     fn read_file_not_found() {
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
 
         let err = transport
             .read_file("nonexistent.json")
@@ -213,7 +213,7 @@ mod test {
         let filename = "poem.txt";
         temp.child(filename).write_str(content).unwrap();
 
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
 
         assert_eq!(
             transport.metadata(filename).unwrap(),
@@ -235,7 +235,7 @@ mod test {
             .write_str("Morning coffee")
             .unwrap();
 
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
         let root_list = transport.list_dir(".").unwrap();
         assert_eq!(root_list.files, ["root file"]);
         assert_eq!(root_list.dirs, ["subdir"]);
@@ -253,7 +253,7 @@ mod test {
     #[test]
     fn write_file() {
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
 
         transport.create_dir("subdir").unwrap();
         transport
@@ -275,7 +275,7 @@ mod test {
         use std::os::unix::prelude::PermissionsExt;
 
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
         temp.child("file").touch().unwrap();
         fs::set_permissions(temp.child("file").path(), fs::Permissions::from_mode(0o000))
             .expect("set_permissions");
@@ -288,7 +288,7 @@ mod test {
     #[test]
     fn write_file_can_overwrite() {
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
         let filename = "filename";
         transport
             .write_file(filename, b"original content")
@@ -305,7 +305,7 @@ mod test {
     #[test]
     fn create_existing_dir() {
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
 
         transport.create_dir("aaa").unwrap();
         transport.create_dir("aaa").unwrap();
@@ -317,7 +317,7 @@ mod test {
     #[test]
     fn sub_transport() {
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
 
         transport.create_dir("aaa").unwrap();
         transport.create_dir("aaa/bbb").unwrap();
@@ -334,7 +334,7 @@ mod test {
     #[test]
     fn remove_dir_all() {
         let temp = assert_fs::TempDir::new().unwrap();
-        let transport = Transport2::local(temp.path());
+        let transport = Transport::local(temp.path());
 
         transport.create_dir("aaa").unwrap();
         transport.create_dir("aaa/bbb").unwrap();

--- a/src/transport/s3.rs
+++ b/src/transport/s3.rs
@@ -76,10 +76,7 @@ impl Protocol {
             .map_err(|err| Error::io_error(Path::new(""), err))?;
 
         let bucket = url.authority().to_owned();
-        assert!(
-            !bucket.is_empty(),
-            "S3 bucket name is empty in {url:?}"
-        );
+        assert!(!bucket.is_empty(), "S3 bucket name is empty in {url:?}");
 
         // Find the bucket region.
         let config = load_aws_config(&runtime, None);

--- a/src/transport/s3.rs
+++ b/src/transport/s3.rs
@@ -47,6 +47,24 @@ use url::Url;
 
 use super::{Error, ErrorKind, Kind, ListDir, Metadata, Result, Transport};
 
+pub(super) struct Protocol {
+    s3transport: Arc<S3Transport>,
+}
+
+impl Protocol {
+    pub(super) fn new(url: &Url) -> Result<Self> {
+        Ok(Protocol {
+            s3transport: S3Transport::new(url)?,
+        })
+    }
+}
+
+impl super::Protocol for Protocol {
+    fn read_file(&self, relpath: &str) -> Result<Bytes> {
+        self.s3transport.read_file(relpath)
+    }
+}
+
 pub struct S3Transport {
     /// Tokio runtime specifically for S3 IO.
     ///

--- a/src/transport/sftp.rs
+++ b/src/transport/sftp.rs
@@ -32,6 +32,38 @@ impl super::Protocol for Protocol {
     fn read_file(&self, relpath: &str) -> Result<Bytes> {
         self.transport.read_file(relpath)
     }
+
+    fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()> {
+        todo!()
+    }
+
+    fn list_dir(&self, relpath: &str) -> Result<ListDir> {
+        todo!()
+    }
+
+    fn create_dir(&self, relpath: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn metadata(&self, relpath: &str) -> Result<super::Metadata> {
+        todo!()
+    }
+
+    fn remove_file(&self, relpath: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn remove_dir_all(&self, relpath: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn chdir(&self, relpath: &str) -> Arc<dyn super::Protocol> {
+        todo!()
+    }
+
+    fn url(&self) -> &Url {
+        todo!()
+    }
 }
 
 /// Archive file I/O over SFTP.

--- a/src/transport/sftp.rs
+++ b/src/transport/sftp.rs
@@ -9,73 +9,21 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, instrument, trace, warn};
 use url::Url;
 
 use crate::Kind;
 
-use super::{Error, ErrorKind, ListDir, Result, Transport};
+use super::{Error, ErrorKind, ListDir, Result};
 
 pub(super) struct Protocol {
-    transport: SftpTransport,
-}
-
-impl Protocol {
-    pub fn new(url: &Url) -> Result<Self> {
-        Ok(Protocol {
-            transport: SftpTransport::new(url)?,
-        })
-    }
-}
-
-impl super::Protocol for Protocol {
-    fn read_file(&self, relpath: &str) -> Result<Bytes> {
-        self.transport.read_file(relpath)
-    }
-
-    fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()> {
-        todo!()
-    }
-
-    fn list_dir(&self, relpath: &str) -> Result<ListDir> {
-        todo!()
-    }
-
-    fn create_dir(&self, relpath: &str) -> Result<()> {
-        todo!()
-    }
-
-    fn metadata(&self, relpath: &str) -> Result<super::Metadata> {
-        todo!()
-    }
-
-    fn remove_file(&self, relpath: &str) -> Result<()> {
-        todo!()
-    }
-
-    fn remove_dir_all(&self, relpath: &str) -> Result<()> {
-        todo!()
-    }
-
-    fn chdir(&self, relpath: &str) -> Arc<dyn super::Protocol> {
-        todo!()
-    }
-
-    fn url(&self) -> &Url {
-        todo!()
-    }
-}
-
-/// Archive file I/O over SFTP.
-#[derive(Clone)]
-pub struct SftpTransport {
     url: Url,
     sftp: Arc<ssh2::Sftp>,
     base_path: PathBuf,
 }
 
-impl SftpTransport {
-    pub fn new(url: &Url) -> Result<SftpTransport> {
+impl Protocol {
+    pub fn new(url: &Url) -> Result<Self> {
         assert_eq!(url.scheme(), "sftp");
         let addr = format!(
             "{}:{}",
@@ -116,9 +64,9 @@ impl SftpTransport {
             error!(?err, "Error opening SFTP session");
             ssh_error(err, url.as_ref())
         })?;
-        Ok(SftpTransport {
+        Ok(Protocol {
+            url: url.to_owned(),
             sftp: Arc::new(sftp),
-            url: url.clone(),
             base_path: url.path().into(),
         })
     }
@@ -131,15 +79,7 @@ impl SftpTransport {
     }
 }
 
-impl fmt::Debug for SftpTransport {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SftpTransport")
-            .field("url", &self.url)
-            .finish()
-    }
-}
-
-impl Transport for SftpTransport {
+impl super::Protocol for Protocol {
     fn list_dir(&self, path: &str) -> Result<ListDir> {
         let full_path = &self.base_path.join(path);
         trace!("iter_dir_entries {:?}", full_path);
@@ -242,8 +182,8 @@ impl Transport for SftpTransport {
             .map_err(|err| ssh_error(err, relpath))
     }
 
+    #[instrument]
     fn remove_dir_all(&self, path: &str) -> Result<()> {
-        trace!(?path, "SftpTransport::remove_dir_all");
         let mut dirs_to_walk = vec![path.to_owned()];
         let mut dirs_to_delete = vec![path.to_owned()];
         while let Some(dir) = dirs_to_walk.pop() {
@@ -274,15 +214,26 @@ impl Transport for SftpTransport {
         // self.sftp.rmdir(&full_path).map_err(translate_error)
     }
 
-    fn sub_transport(&self, relpath: &str) -> Arc<dyn Transport> {
+    fn chdir(&self, relpath: &str) -> Arc<dyn super::Protocol> {
         let base_path = self.base_path.join(relpath);
-        let mut url = self.url.clone();
-        url.set_path(base_path.to_str().unwrap());
-        Arc::new(SftpTransport {
+        let url = self.url.join(relpath).expect("join URL");
+        Arc::new(Protocol {
             url,
             sftp: Arc::clone(&self.sftp),
             base_path,
         })
+    }
+
+    fn url(&self) -> &Url {
+        &self.url
+    }
+}
+
+impl fmt::Debug for Protocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("sftp::Protocol")
+            .field("url", &self.url)
+            .finish()
     }
 }
 

--- a/src/transport/sftp.rs
+++ b/src/transport/sftp.rs
@@ -16,6 +16,24 @@ use crate::Kind;
 
 use super::{Error, ErrorKind, ListDir, Result, Transport};
 
+pub(super) struct Protocol {
+    transport: SftpTransport,
+}
+
+impl Protocol {
+    pub fn new(url: &Url) -> Result<Self> {
+        Ok(Protocol {
+            transport: SftpTransport::new(url)?,
+        })
+    }
+}
+
+impl super::Protocol for Protocol {
+    fn read_file(&self, relpath: &str) -> Result<Bytes> {
+        self.transport.read_file(relpath)
+    }
+}
+
 /// Archive file I/O over SFTP.
 #[derive(Clone)]
 pub struct SftpTransport {

--- a/tests/damage.rs
+++ b/tests/damage.rs
@@ -46,7 +46,7 @@ use tracing_test::traced_test;
 
 use conserve::counters::Counter;
 use conserve::monitor::test::TestMonitor;
-use conserve::transport::Transport2;
+use conserve::transport::Transport;
 use conserve::{
     backup, restore, Apath, Archive, BackupOptions, BandId, BandSelectionPolicy, BlockHash,
     EntryTrait, Exclude, RestoreOptions, ValidateOptions,
@@ -113,7 +113,7 @@ fn backup_after_damage(
     action.damage(&location.to_path(&archive_dir));
 
     // Open the archive again to avoid cache effects.
-    let archive = Archive::open(Transport2::local(archive_dir.path())).expect("open archive");
+    let archive = Archive::open(Transport::local(archive_dir.path())).expect("open archive");
 
     // A second backup should succeed.
     changes.apply(&source_dir);
@@ -262,7 +262,7 @@ impl DamageLocation {
                 .join(BandId::from(*band_id).to_string())
                 .join("BANDTAIL"),
             DamageLocation::Block(block_index) => {
-                let archive = Archive::open(Transport2::local(archive_dir)).expect("open archive");
+                let archive = Archive::open(Transport::local(archive_dir)).expect("open archive");
                 let block_dir = archive.block_dir();
                 let block_hash = block_dir
                     .blocks(TestMonitor::arc())

--- a/tests/damage.rs
+++ b/tests/damage.rs
@@ -46,7 +46,7 @@ use tracing_test::traced_test;
 
 use conserve::counters::Counter;
 use conserve::monitor::test::TestMonitor;
-use conserve::transport::open_local_transport;
+use conserve::transport::Transport2;
 use conserve::{
     backup, restore, Apath, Archive, BackupOptions, BandId, BandSelectionPolicy, BlockHash,
     EntryTrait, Exclude, RestoreOptions, ValidateOptions,
@@ -113,9 +113,7 @@ fn backup_after_damage(
     action.damage(&location.to_path(&archive_dir));
 
     // Open the archive again to avoid cache effects.
-    let archive =
-        Archive::open(conserve::transport::open_local_transport(archive_dir.path()).unwrap())
-            .expect("open archive");
+    let archive = Archive::open(Transport2::local(archive_dir.path())).expect("open archive");
 
     // A second backup should succeed.
     changes.apply(&source_dir);
@@ -264,9 +262,7 @@ impl DamageLocation {
                 .join(BandId::from(*band_id).to_string())
                 .join("BANDTAIL"),
             DamageLocation::Block(block_index) => {
-                let archive =
-                    Archive::open(open_local_transport(archive_dir).expect("open transport"))
-                        .expect("open archive");
+                let archive = Archive::open(Transport2::local(archive_dir)).expect("open archive");
                 let block_dir = archive.block_dir();
                 let block_hash = block_dir
                     .blocks(TestMonitor::arc())

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -19,8 +19,8 @@ use assert_fs::TempDir;
 use conserve::monitor::test::TestMonitor;
 use fail::FailScenario;
 
+use crate::transport::Transport;
 use conserve::*;
-use transport::Transport;
 
 #[test]
 fn create_dir_permission_denied() {

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -20,13 +20,13 @@ use conserve::monitor::test::TestMonitor;
 use fail::FailScenario;
 
 use conserve::*;
-use transport::Transport2;
+use transport::Transport;
 
 #[test]
 fn create_dir_permission_denied() {
     let scenario = FailScenario::setup();
     fail::cfg("restore::create-dir", "return").unwrap();
-    let archive = Archive::open(Transport2::local(Path::new(
+    let archive = Archive::open(Transport::local(Path::new(
         "testdata/archive/simple/v0.6.10",
     )))
     .unwrap();

--- a/tests/failpoints.rs
+++ b/tests/failpoints.rs
@@ -17,18 +17,19 @@ use std::path::Path;
 
 use assert_fs::TempDir;
 use conserve::monitor::test::TestMonitor;
-use conserve::transport::open_local_transport;
 use fail::FailScenario;
 
 use conserve::*;
+use transport::Transport2;
 
 #[test]
 fn create_dir_permission_denied() {
     let scenario = FailScenario::setup();
     fail::cfg("restore::create-dir", "return").unwrap();
-    let archive =
-        Archive::open(open_local_transport(Path::new("testdata/archive/simple/v0.6.10")).unwrap())
-            .unwrap();
+    let archive = Archive::open(Transport2::local(Path::new(
+        "testdata/archive/simple/v0.6.10",
+    )))
+    .unwrap();
     let options = RestoreOptions {
         ..RestoreOptions::default()
     };

--- a/tests/format_flags.rs
+++ b/tests/format_flags.rs
@@ -42,7 +42,7 @@ fn unknown_format_flag_fails_to_open() {
         "format_flags": ["wibble"]
     });
     af.transport()
-        .sub_transport("b0000")
+        .chdir("b0000")
         .write_file("BANDHEAD", &serde_json::to_vec(&head).unwrap())
         .unwrap();
 

--- a/tests/transport.rs
+++ b/tests/transport.rs
@@ -10,14 +10,16 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+use std::path::Path;
+
 use assert_fs::prelude::*;
 use url::Url;
 
-use conserve::transport::{open_transport, ListDir};
+use conserve::transport::{ListDir, Transport2};
 
 #[test]
 fn open_local() {
-    open_transport("/backup").unwrap();
+    Transport2::local(Path::new("/backup"));
 }
 
 #[test]
@@ -29,7 +31,7 @@ fn list_dir_names() {
 
     let url = Url::from_directory_path(temp.path()).unwrap();
     dbg!(&url);
-    let transport = open_transport(url.as_str()).unwrap();
+    let transport = Transport2::new(url.as_str()).unwrap();
     dbg!(&transport);
 
     let ListDir { mut files, dirs } = transport.list_dir("").unwrap();
@@ -49,20 +51,20 @@ fn parse_location_urls() {
         "c:/backup/repo",
         r"c:\backup\repo\",
     ] {
-        assert!(open_transport(n).is_ok(), "Failed to parse {n:?}");
+        assert!(Transport2::new(n).is_ok(), "Failed to parse {n:?}");
     }
 }
 
 #[test]
 fn unsupported_location_urls() {
     assert_eq!(
-        open_transport("http://conserve.example/repo")
+        Transport2::new("http://conserve.example/repo")
             .unwrap_err()
             .to_string(),
         "Unsupported URL scheme: http://conserve.example/repo"
     );
     assert_eq!(
-        open_transport("ftp://user@conserve.example/repo")
+        Transport2::new("ftp://user@conserve.example/repo")
             .unwrap_err()
             .to_string(),
         "Unsupported URL scheme: ftp://user@conserve.example/repo"

--- a/tests/transport.rs
+++ b/tests/transport.rs
@@ -15,11 +15,11 @@ use std::path::Path;
 use assert_fs::prelude::*;
 use url::Url;
 
-use conserve::transport::{ListDir, Transport2};
+use conserve::transport::{ListDir, Transport};
 
 #[test]
 fn open_local() {
-    Transport2::local(Path::new("/backup"));
+    Transport::local(Path::new("/backup"));
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn list_dir_names() {
 
     let url = Url::from_directory_path(temp.path()).unwrap();
     dbg!(&url);
-    let transport = Transport2::new(url.as_str()).unwrap();
+    let transport = Transport::new(url.as_str()).unwrap();
     dbg!(&transport);
 
     let ListDir { mut files, dirs } = transport.list_dir("").unwrap();
@@ -51,20 +51,20 @@ fn parse_location_urls() {
         "c:/backup/repo",
         r"c:\backup\repo\",
     ] {
-        assert!(Transport2::new(n).is_ok(), "Failed to parse {n:?}");
+        assert!(Transport::new(n).is_ok(), "Failed to parse {n:?}");
     }
 }
 
 #[test]
 fn unsupported_location_urls() {
     assert_eq!(
-        Transport2::new("http://conserve.example/repo")
+        Transport::new("http://conserve.example/repo")
             .unwrap_err()
             .to_string(),
         "Unsupported URL scheme: http://conserve.example/repo"
     );
     assert_eq!(
-        Transport2::new("ftp://user@conserve.example/repo")
+        Transport::new("ftp://user@conserve.example/repo")
             .unwrap_err()
             .to_string(),
         "Unsupported URL scheme: ftp://user@conserve.example/repo"

--- a/tests/transport.rs
+++ b/tests/transport.rs
@@ -59,12 +59,12 @@ fn unsupported_location_urls() {
         open_transport("http://conserve.example/repo")
             .unwrap_err()
             .to_string(),
-        "Unsupported URL scheme \"http\""
+        "Unsupported URL scheme: http://conserve.example/repo"
     );
     assert_eq!(
         open_transport("ftp://user@conserve.example/repo")
             .unwrap_err()
             .to_string(),
-        "Unsupported URL scheme \"ftp\""
+        "Unsupported URL scheme: ftp://user@conserve.example/repo"
     );
 }


### PR DESCRIPTION
Previously, clients needed to deal with an `Arc<dyn Transport>`, which was unfortunate because it's widely used. Now they can just use a `&Transport`, which is cheaply cloneable. An object pointer to the particular implementation is held internally.