### PR TITLE
Distinguish overwrite vs create new in Transport

### DIFF
--- a/src/gc_lock.rs
+++ b/src/gc_lock.rs
@@ -31,6 +31,8 @@
 //! delete but before starting to actually delete them, we check that no
 //! new bands have been created.
 
+use transport::WriteMode;
+
 use crate::*;
 
 pub static GC_LOCK: &str = "GC_LOCK";
@@ -63,7 +65,9 @@ impl GarbageCollectionLock {
         if archive.transport().is_file(GC_LOCK).unwrap_or(true) {
             return Err(Error::GarbageCollectionLockHeld);
         }
-        archive.transport().write_file(GC_LOCK, b"{}\n")?;
+        archive
+            .transport()
+            .write_file(GC_LOCK, b"{}\n", WriteMode::CreateNew)?;
         Ok(GarbageCollectionLock { archive, band_id })
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -23,6 +23,7 @@ use crate::transport::Transport;
 use itertools::Itertools;
 use time::OffsetDateTime;
 use tracing::{debug, debug_span, error};
+use transport::WriteMode;
 
 use crate::compress::snappy::{Compressor, Decompressor};
 use crate::counters::Counter;
@@ -253,7 +254,8 @@ impl IndexWriter {
             self.transport.create_dir(&subdir_relpath(self.sequence))?;
         }
         let compressed_bytes = self.compressor.compress(&json)?;
-        self.transport.write_file(&relpath, &compressed_bytes)?;
+        self.transport
+            .write_file(&relpath, &compressed_bytes, WriteMode::CreateNew)?;
         self.hunks_written += 1;
         monitor.count(Counter::IndexWrites, 1);
         monitor.count(Counter::IndexWriteCompressedBytes, compressed_bytes.len());

--- a/src/jsonio.rs
+++ b/src/jsonio.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 
 use serde::de::DeserializeOwned;
 
-use crate::transport::{self, Transport};
+use crate::transport::{self, Transport, WriteMode};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -54,7 +54,7 @@ where
     })?;
     s.push('\n');
     transport
-        .write_file(relpath, s.as_bytes())
+        .write_file(relpath, s.as_bytes(), WriteMode::CreateNew)
         .map_err(Error::from)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,6 @@ pub const ARCHIVE_VERSION: &str = "0.6";
 
 pub const SYMLINKS_SUPPORTED: bool = cfg!(target_family = "unix");
 
-/// Temporary files in the archive have this prefix.
-const TMP_PREFIX: &str = "tmp";
-
 /// Metadata file in the band directory.
 static BAND_HEAD_FILENAME: &str = "BANDHEAD";
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -116,8 +116,8 @@ impl Transport {
         }
     }
 
-    pub fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()> {
-        self.protocol.write_file(relpath, content)
+    pub fn write_file(&self, relpath: &str, content: &[u8], mode: WriteMode) -> Result<()> {
+        self.protocol.write_file(relpath, content, mode)
     }
 
     pub fn create_dir(&self, relpath: &str) -> Result<()> {
@@ -163,9 +163,18 @@ impl fmt::Debug for Transport {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteMode {
+    /// Create the file if it does not exist, or overwrite it if it does.
+    Overwrite,
+
+    /// Create the file if it does not exist, or fail if it does.
+    CreateNew,
+}
+
 trait Protocol: Send + Sync {
     fn read_file(&self, path: &str) -> Result<Bytes>;
-    fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()>;
+    fn write_file(&self, relpath: &str, content: &[u8], mode: WriteMode) -> Result<()>;
     fn list_dir(&self, relpath: &str) -> Result<ListDir>;
     fn create_dir(&self, relpath: &str) -> Result<()>;
     fn metadata(&self, relpath: &str) -> Result<Metadata>;

--- a/src/transport/s3.rs
+++ b/src/transport/s3.rs
@@ -42,7 +42,7 @@ use aws_types::SdkConfig;
 use base64::Engine;
 use bytes::Bytes;
 use tokio::runtime::Runtime;
-use tracing::{debug, trace, trace_span};
+use tracing::{debug, instrument, trace, trace_span};
 use url::Url;
 
 use super::{Error, ErrorKind, Kind, ListDir, Metadata, Result, WriteMode};
@@ -261,12 +261,12 @@ impl super::Protocol for Protocol {
         Ok(())
     }
 
+    #[instrument(skip(self, content))]
     fn write_file(&self, relpath: &str, content: &[u8], write_mode: WriteMode) -> Result<()> {
-        let _span = trace_span!("S3Transport::write_file", %relpath).entered();
         let key = self.join_path(relpath);
         let crc32c =
             base64::engine::general_purpose::STANDARD.encode(crc32c::crc32c(content).to_be_bytes());
-        let request = self
+        let mut request = self
             .client
             .put_object()
             .bucket(&self.bucket)
@@ -274,6 +274,9 @@ impl super::Protocol for Protocol {
             .storage_class(self.storage_class.clone())
             .checksum_crc32_c(crc32c)
             .body(content.to_owned().into());
+        if write_mode == WriteMode::CreateNew {
+            request = request.if_none_match("*");
+        }
         let response = self.runtime.block_on(request.send());
         // trace!(?response);
         response.map_err(|err| s3_error(key, err))?;

--- a/src/transport/s3.rs
+++ b/src/transport/s3.rs
@@ -45,7 +45,7 @@ use tokio::runtime::Runtime;
 use tracing::{debug, trace, trace_span};
 use url::Url;
 
-use super::{Error, ErrorKind, Kind, ListDir, Metadata, Result};
+use super::{Error, ErrorKind, Kind, ListDir, Metadata, Result, WriteMode};
 
 pub(super) struct Protocol {
     url: Url,
@@ -261,7 +261,7 @@ impl super::Protocol for Protocol {
         Ok(())
     }
 
-    fn write_file(&self, relpath: &str, content: &[u8]) -> Result<()> {
+    fn write_file(&self, relpath: &str, content: &[u8], write_mode: WriteMode) -> Result<()> {
         let _span = trace_span!("S3Transport::write_file", %relpath).entered();
         let key = self.join_path(relpath);
         let crc32c =

--- a/tests/format_flags.rs
+++ b/tests/format_flags.rs
@@ -5,6 +5,7 @@
 
 use conserve::test_fixtures::ScratchArchive;
 use conserve::*;
+use transport::WriteMode;
 
 #[test]
 // This can be updated if/when Conserve does start writing some flags by default.
@@ -43,7 +44,11 @@ fn unknown_format_flag_fails_to_open() {
     });
     af.transport()
         .chdir("b0000")
-        .write_file("BANDHEAD", &serde_json::to_vec(&head).unwrap())
+        .write_file(
+            "BANDHEAD",
+            &serde_json::to_vec(&head).unwrap(),
+            WriteMode::CreateNew,
+        )
         .unwrap();
 
     let err = Band::open(&af, BandId::zero()).unwrap_err();


### PR DESCRIPTION
* Stop using temp files in local archives
* Be more explicit about when overwrite is expected (rarely)