### PR TITLE
Adding support for .gitignore file like ignorefiles (and fix Windows build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "futures",
  "globset",
  "hex",
+ "ignore",
  "indoc",
  "itertools",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ filetime = "0.2"
 futures = { version = "0.3", optional = true }
 globset = "0.4.5"
 hex = "0.4.2"
+ignore = "0.4.25"
 itertools = "0.14"
 lazy_static = "1.4.0"
 libssh2-sys = { version = "0.3.0", optional = true }

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -520,7 +520,7 @@ impl Command {
             } => {
                 use std::io::Read;
 
-                let archive = Archive::open(Transport::new(archive)?)?;
+                let archive = Archive::open(Transport::new(archive).await?).await?;
                 let options = MountOptions { clean: *cleanup };
                 let projection = match mount(archive, destination, options) {
                     Ok(handle) => handle,

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -211,6 +211,7 @@ enum Command {
         verbose: bool,
         #[clap(flatten)]
         path_filter: PathFilterOptions,
+        #[arg(long = "only", short = 'i')]
         only_subtree: Option<Apath>,
         #[arg(long)]
         no_stats: bool,

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -80,11 +80,8 @@ enum Command {
         /// Print copied file names.
         #[arg(long, short)]
         verbose: bool,
-        #[arg(long, short)]
-        exclude: Vec<String>,
-        /// Read a list of globs to exclude from this file.
-        #[arg(long, short = 'E')]
-        exclude_from: Vec<String>,
+        #[clap(flatten)]
+        path_filter: PathFilterOptions,
         /// Don't print statistics after the backup completes.
         #[arg(long)]
         no_stats: bool,
@@ -122,10 +119,8 @@ enum Command {
         /// Select the version from the archive to compare: by default, the latest.
         #[arg(long, short)]
         backup: Option<BandId>,
-        #[arg(long, short)]
-        exclude: Vec<String>,
-        #[arg(long, short = 'E')]
-        exclude_from: Vec<String>,
+        #[clap(flatten)]
+        path_filter: PathFilterOptions,
         #[arg(long)]
         include_unchanged: bool,
 
@@ -159,11 +154,8 @@ enum Command {
         #[command(flatten)]
         stos: StoredTreeOrSource,
 
-        #[arg(long, short)]
-        exclude: Vec<String>,
-
-        #[arg(long, short = 'E')]
-        exclude_from: Vec<String>,
+        #[clap(flatten)]
+        path_filter: PathFilterOptions,
 
         /// Print entries as json.
         #[arg(long, short)]
@@ -217,11 +209,8 @@ enum Command {
         force_overwrite: bool,
         #[arg(long, short)]
         verbose: bool,
-        #[arg(long, short)]
-        exclude: Vec<String>,
-        #[arg(long, short = 'E')]
-        exclude_from: Vec<String>,
-        #[arg(long = "only", short = 'i')]
+        #[clap(flatten)]
+        path_filter: PathFilterOptions,
         only_subtree: Option<Apath>,
         #[arg(long)]
         no_stats: bool,
@@ -239,10 +228,8 @@ enum Command {
         #[arg(long)]
         bytes: bool,
 
-        #[arg(long, short)]
-        exclude: Vec<String>,
-        #[arg(long, short = 'E')]
-        exclude_from: Vec<String>,
+        #[clap(flatten)]
+        path_filter: PathFilterOptions,
     },
 
     /// Check that an archive is internally consistent.
@@ -293,6 +280,17 @@ struct StoredTreeOrSource {
     backup: Option<BandId>,
 }
 
+#[derive(Debug, Parser)]
+struct PathFilterOptions {
+    /// Ignore paths matching the glob pattern.
+    #[arg(long, short)]
+    exclude: Vec<String>,
+
+    /// Read a list of globs to exclude from this file.
+    #[arg(long, short = 'E')]
+    exclude_from: Vec<String>,
+}
+
 /// Show debugging information.
 #[derive(Debug, Subcommand)]
 enum Debug {
@@ -328,6 +326,12 @@ impl std::process::Termination for ExitCode {
     }
 }
 
+impl PathFilterOptions {
+    pub fn create_path_filter(&self) -> Result<Exclude> {
+        Exclude::from_patterns_and_files(&self.exclude, &self.exclude_from)
+    }
+}
+
 impl Command {
     #[tokio::main]
     async fn run(&self, monitor: Arc<TermUiMonitor>) -> Result<ExitCode> {
@@ -336,15 +340,14 @@ impl Command {
             Command::Backup {
                 archive,
                 changes_json,
-                exclude,
-                exclude_from,
+                path_filter,
                 long_listing,
                 no_stats,
                 source,
                 verbose,
             } => {
                 let options = BackupOptions {
-                    exclude: Exclude::from_patterns_and_files(exclude, exclude_from)?,
+                    exclude: path_filter.create_path_filter()?,
                     change_callback: make_change_callback(
                         *verbose,
                         *long_listing,
@@ -425,15 +428,14 @@ impl Command {
                 archive,
                 source,
                 backup,
-                exclude,
-                exclude_from,
+                path_filter,
                 include_unchanged,
                 json,
             } => {
                 let st = stored_tree_from_opt(archive, backup).await?;
                 let source = SourceTree::open(source)?;
                 let options = DiffOptions {
-                    exclude: Exclude::from_patterns_and_files(exclude, exclude_from)?,
+                    exclude: path_filter.create_path_filter()?,
                     include_unchanged: *include_unchanged,
                 };
                 let mut bw = BufWriter::new(stdout);
@@ -474,16 +476,15 @@ impl Command {
             Command::Ls {
                 json,
                 stos,
-                exclude,
-                exclude_from,
+                path_filter,
                 long_listing,
             } => {
-                let exclude = Exclude::from_patterns_and_files(exclude, exclude_from)?;
+                let path_filter = path_filter.create_path_filter()?;
                 if let Some(archive) = &stos.archive {
                     // TODO: Option for subtree.
                     let mut stitch = stored_tree_from_opt(archive, &stos.backup)
                         .await?
-                        .iter_entries(Apath::root(), exclude, monitor.clone());
+                        .iter_entries(Apath::root(), path_filter, monitor.clone());
                     while let Some(entry) = stitch.next().await {
                         // Strip off index internals like addresses; this seems
                         // like not quite the right way to do it, maybe the types should
@@ -499,7 +500,7 @@ impl Command {
                     // TODO: Can maybe unify these more when the source tree iter is also async.
                     let entry_iter = SourceTree::open(stos.source.clone().unwrap())?.iter_entries(
                         Apath::root(),
-                        exclude,
+                        path_filter,
                         monitor.clone(),
                     )?;
                     for entry in entry_iter {
@@ -555,8 +556,7 @@ impl Command {
                 changes_json,
                 verbose,
                 force_overwrite,
-                exclude,
-                exclude_from,
+                path_filter,
                 only_subtree,
                 long_listing,
                 no_stats,
@@ -565,7 +565,7 @@ impl Command {
                 let archive = Archive::open(Transport::new(archive).await?).await?;
                 let _ = no_stats; // accepted but ignored; we never currently print stats
                 let options = RestoreOptions {
-                    exclude: Exclude::from_patterns_and_files(exclude, exclude_from)?,
+                    exclude: path_filter.create_path_filter()?,
                     only_subtree: only_subtree.clone(),
                     band_selection,
                     overwrite: *force_overwrite,
@@ -582,10 +582,9 @@ impl Command {
             Command::Size {
                 stos,
                 bytes,
-                exclude,
-                exclude_from,
+                path_filter,
             } => {
-                let exclude = Exclude::from_patterns_and_files(exclude, exclude_from)?;
+                let exclude = path_filter.create_path_filter()?;
                 let size = if let Some(archive) = &stos.archive {
                     stored_tree_from_opt(archive, &stos.backup)
                         .await?

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -332,7 +332,7 @@ impl std::process::Termination for ExitCode {
 }
 
 impl PathFilterOptions {
-    pub fn create_path_filter(&self) -> Result<Exclude> {
+    pub fn to_exclude(&self) -> Result<Exclude> {
         if let Some(file) = &self.ignore_file {
             Exclude::from_ignorefile(file)
         } else {
@@ -356,7 +356,7 @@ impl Command {
                 verbose,
             } => {
                 let options = BackupOptions {
-                    exclude: path_filter.create_path_filter()?,
+                    exclude: path_filter.to_exclude()?,
                     change_callback: make_change_callback(
                         *verbose,
                         *long_listing,
@@ -444,7 +444,7 @@ impl Command {
                 let st = stored_tree_from_opt(archive, backup).await?;
                 let source = SourceTree::open(source)?;
                 let options = DiffOptions {
-                    exclude: path_filter.create_path_filter()?,
+                    exclude: path_filter.to_exclude()?,
                     include_unchanged: *include_unchanged,
                 };
                 let mut bw = BufWriter::new(stdout);
@@ -488,7 +488,7 @@ impl Command {
                 path_filter,
                 long_listing,
             } => {
-                let path_filter = path_filter.create_path_filter()?;
+                let path_filter = path_filter.to_exclude()?;
                 if let Some(archive) = &stos.archive {
                     // TODO: Option for subtree.
                     let mut stitch = stored_tree_from_opt(archive, &stos.backup)
@@ -574,7 +574,7 @@ impl Command {
                 let archive = Archive::open(Transport::new(archive).await?).await?;
                 let _ = no_stats; // accepted but ignored; we never currently print stats
                 let options = RestoreOptions {
-                    exclude: path_filter.create_path_filter()?,
+                    exclude: path_filter.to_exclude()?,
                     only_subtree: only_subtree.clone(),
                     band_selection,
                     overwrite: *force_overwrite,
@@ -593,7 +593,7 @@ impl Command {
                 bytes,
                 path_filter,
             } => {
-                let exclude = path_filter.create_path_filter()?;
+                let exclude = path_filter.to_exclude()?;
                 let size = if let Some(archive) = &stos.archive {
                     stored_tree_from_opt(archive, &stos.backup)
                         .await?

--- a/src/bin/conserve.rs
+++ b/src/bin/conserve.rs
@@ -283,12 +283,16 @@ struct StoredTreeOrSource {
 #[derive(Debug, Parser)]
 struct PathFilterOptions {
     /// Ignore paths matching the glob pattern.
-    #[arg(long, short)]
+    #[arg(long, short, conflicts_with = "ignore_file")]
     exclude: Vec<String>,
 
     /// Read a list of globs to exclude from this file.
-    #[arg(long, short = 'E')]
+    #[arg(long, short = 'E', conflicts_with = "ignore_file")]
     exclude_from: Vec<String>,
+
+    /// Specify a gitignore like ignorefile
+    #[arg(long, short)]
+    ignore_file: Option<PathBuf>,
 }
 
 /// Show debugging information.
@@ -328,7 +332,11 @@ impl std::process::Termination for ExitCode {
 
 impl PathFilterOptions {
     pub fn create_path_filter(&self) -> Result<Exclude> {
-        Exclude::from_patterns_and_files(&self.exclude, &self.exclude_from)
+        if let Some(file) = &self.ignore_file {
+            Exclude::from_ignorefile(file)
+        } else {
+            Exclude::from_patterns_and_files(&self.exclude, &self.exclude_from)
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -205,6 +205,12 @@ pub enum Error {
         #[from]
         source: windows_projfs::Error,
     },
+
+    #[error(transparent)]
+    Ignorefile {
+        #[from]
+        source: ignore::Error,
+    },
 }
 
 impl From<jsonio::Error> for Error {

--- a/src/excludes.rs
+++ b/src/excludes.rs
@@ -25,13 +25,15 @@ use std::iter::empty;
 use std::path::Path;
 
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
 use super::*;
 
 /// Describes which files to exclude from a backup, restore, etc.
 #[derive(Clone, Debug)]
-pub struct Exclude {
-    globset: GlobSet,
+pub enum Exclude {
+    Pattern(GlobSet),
+    Ignorefile(Gitignore),
     // TODO: Control of matching cachedir.
 }
 
@@ -61,16 +63,22 @@ impl Exclude {
         for path in exclude_from {
             add_patterns_from_file(&mut gsb, path.as_ref())?;
         }
-        Ok(Exclude {
-            globset: gsb.build()?,
-        })
+        Ok(Exclude::Pattern(gsb.build()?))
+    }
+
+    pub fn from_ignorefile(file: impl AsRef<Path>) -> Result<Exclude> {
+        let mut builder = GitignoreBuilder::new("/");
+
+        if let Some(error) = builder.add(file) {
+            return Err(error.into());
+        }
+
+        Ok(Exclude::Ignorefile(builder.build()?))
     }
 
     /// Exclude nothing, even items that might be excluded by default.
     pub fn nothing() -> Exclude {
-        Exclude {
-            globset: GlobSet::empty(),
-        }
+        Exclude::Pattern(GlobSet::empty())
     }
 
     /// True if this apath should be excluded.
@@ -80,7 +88,10 @@ impl Exclude {
         A: ?Sized,
     {
         let apath: Apath = apath.into();
-        self.globset.is_match(apath)
+        match self {
+            Self::Pattern(globset) => globset.is_match(apath),
+            Self::Ignorefile(inner) => inner.matched(apath, false).is_ignore(),
+        }
     }
 }
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -15,7 +15,6 @@
 
 use std::time::Duration;
 
-
 use crate::stats::Sizes;
 
 pub fn bytes_to_human_mb(s: u64) -> String {

--- a/src/mount/projfs.rs
+++ b/src/mount/projfs.rs
@@ -12,8 +12,10 @@ use std::{
 };
 
 use bytes::Bytes;
+use futures::executor;
 use itertools::Itertools;
 use lru::LruCache;
+use tokio::runtime::Handle;
 use tracing::{debug, info, warn};
 use windows_projfs::{
     DirectoryEntry, DirectoryInfo, FileInfo, Notification, ProjectedFileSystem,
@@ -34,6 +36,7 @@ struct StoredFileReader {
 
 impl StoredFileReader {
     pub fn new(
+        handle: Handle,
         stored_tree: Arc<StoredTree>,
         entry: IndexEntry,
         byte_offset: u64,
@@ -56,10 +59,14 @@ impl StoredFileReader {
                 }
             })
             .map::<Result<Bytes>, _>(move |entry| {
-                let content = stored_tree
-                    .archive
-                    .block_dir
-                    .get_block_content(&entry.hash, monitor.clone())?;
+                let content = handle.block_on(async {
+                    stored_tree
+                        .archive
+                        .block_dir()
+                        .await?
+                        .get_block_content(&entry.hash, monitor.clone())
+                        .await
+                })?;
 
                 Ok(content.slice((entry.start as usize)..(entry.start + entry.len) as usize))
             });
@@ -155,6 +162,7 @@ fn index_entry_to_directory_entry(entry: &IndexEntry) -> Option<DirectoryEntry> 
 }
 
 struct ArchiveProjectionSource {
+    handle: Handle,
     archive: Archive,
 
     stored_tree_cache: Mutex<LruCache<BandId, Arc<StoredTree>>>,
@@ -186,22 +194,25 @@ impl ArchiveProjectionSource {
             .unwrap()
             .try_get_or_insert((band_id, hunk_id), || {
                 let mut index = stored_tree.band().index();
-                Ok(Arc::new(index.read_hunk(hunk_id)?.unwrap_or_default()))
+                Ok(Arc::new(
+                    executor::block_on(index.read_hunk(hunk_id))?.unwrap_or_default(),
+                ))
             })
             .cloned()
     }
 
     pub fn get_or_open_tree(&self, policy: BandSelectionPolicy) -> Result<Arc<StoredTree>> {
-        let band_id = self.archive.resolve_band_id(policy)?;
+        let band_id = executor::block_on(self.archive.resolve_band_id(policy))?;
         self.stored_tree_cache
             .lock()
             .unwrap()
             .try_get_or_insert(band_id, || {
                 debug!("Opening band {}", band_id);
 
-                let stored_tree = self
-                    .archive
-                    .open_stored_tree(BandSelectionPolicy::Specified(band_id))?;
+                let stored_tree = executor::block_on(
+                    self.archive
+                        .open_stored_tree(BandSelectionPolicy::Specified(band_id)),
+                )?;
 
                 Ok(Arc::new(stored_tree))
             })
@@ -220,7 +231,7 @@ impl ArchiveProjectionSource {
                 /* Inform the user that this band has been cached as this is most likely a heavy operation (cpu and memory wise) */
                 info!("Caching files for band {}", stored_tree.band().id());
 
-                let helper = IndexHunkIndex::from_index(&stored_tree.band().index())?;
+                let helper = executor::block_on(IndexHunkIndex::from_index(&stored_tree.band().index()))?;
                 Ok(Arc::new(helper))
             })
             .cloned()
@@ -241,11 +252,11 @@ impl ArchiveProjectionSource {
 
     fn band_id_to_directory_info(&self, policy: BandSelectionPolicy) -> Option<DirectoryInfo> {
         let stored_tree = self.get_or_open_tree(policy).ok()?;
-        let band_info = stored_tree.band().get_info().ok()?;
+        let band_info = executor::block_on(stored_tree.band().get_info()).ok()?;
 
         let timestamp = unix_time_to_windows(
-            band_info.start_time.unix_timestamp(),
-            band_info.start_time.unix_timestamp_nanos() as u32,
+            band_info.start_time.as_second(),
+            band_info.start_time.subsec_nanosecond() as u32,
         );
 
         Some(DirectoryInfo {
@@ -290,9 +301,7 @@ impl ArchiveProjectionSource {
                     BandSelectionPolicy::Specified(band_id.parse::<BandId>()?)
                 } else {
                     /* list bands */
-                    let entries = self
-                        .archive
-                        .list_band_ids()?
+                    let entries = executor::block_on(self.archive.list_band_ids())?
                         .into_iter()
                         .filter_map(|band_id| {
                             self.band_id_to_directory_info(BandSelectionPolicy::Specified(band_id))
@@ -391,6 +400,7 @@ impl ArchiveProjectionSource {
             file_size
         );
         let reader = StoredFileReader::new(
+            self.handle.clone(),
             stored_tree,
             index_entry,
             byte_offset as u64,
@@ -403,6 +413,8 @@ impl ArchiveProjectionSource {
 
 impl ProjectedFileSystemSource for ArchiveProjectionSource {
     fn list_directory(&self, path: &Path) -> Vec<DirectoryEntry> {
+        let _rt_guard = self.handle.enter();
+
         let cached_result = self
             .serve_dir_cache
             .lock()
@@ -435,6 +447,8 @@ impl ProjectedFileSystemSource for ArchiveProjectionSource {
         byte_offset: usize,
         length: usize,
     ) -> std::io::Result<Box<dyn Read>> {
+        let _rt_guard = self.handle.enter();
+
         match self.serve_file(path, byte_offset, length) {
             Ok(reader) => Ok(reader),
             Err(error) => {
@@ -508,6 +522,7 @@ pub fn mount(
     }
 
     let source = ArchiveProjectionSource {
+        handle: Handle::current(),
         archive: archive.clone(),
 
         /* cache at most 16 different bands in parallel */

--- a/src/transport/s3.rs
+++ b/src/transport/s3.rs
@@ -25,9 +25,9 @@
 //    cargo mutants -f s3.rs --no-config -C --features=s3,s3-integration-test
 
 use std::error::Error as StdError;
-use std::fmt;
 use std::sync::Arc;
 use std::time::SystemTime;
+use std::{env, fmt};
 
 use async_trait::async_trait;
 use aws_config::{AppName, BehaviorVersion};
@@ -68,20 +68,25 @@ impl Protocol {
         let bucket = url.authority().to_owned();
         assert!(!bucket.is_empty(), "S3 bucket name is empty in {url:?}");
 
-        // Find the bucket region.
-        let config = load_aws_config(None).await;
-        let client = aws_sdk_s3::Client::new(&config);
-        let location_response = client
-            .get_bucket_location()
-            .set_bucket(Some(bucket.clone()))
-            .send()
-            .await
-            .map_err(|err| s3_error(err, &url))?;
-        debug!(?location_response);
+        let region = if let Some(value) = env::var_os("AWS_REGION") {
+            Some(value.to_string_lossy().to_string())
+        } else {
+            // Find the bucket region.
+            debug!("Resolving S3 bucket region");
+            let config = load_aws_config(None).await;
+            let client = aws_sdk_s3::Client::new(&config);
+            let location_response = client
+                .get_bucket_location()
+                .set_bucket(Some(bucket.clone()))
+                .send()
+                .await
+                .map_err(|err| s3_error(err, &url))?;
+            debug!(?location_response);
 
-        let region = location_response
-            .location_constraint
-            .map(|c| c.as_str().to_owned());
+            location_response
+                .location_constraint
+                .map(|c| c.as_str().to_owned())
+        };
         debug!(?region, "S3 bucket region");
 
         // Make a new client in the right region.


### PR DESCRIPTION
Hey ho,
it’s me again.

As the title suggests, this PR adds support for `.gitignore`-style ignore files.

Additionally combines two minor fixes / features:
- It restores Windows build support, as the previous async-related changes accidentally broke the mount feature there.
- It skips bucket region detection if it has been specified via an environment variable. This allows for custom self hosted S3 implementations like RustFS.